### PR TITLE
Added Apache Parquet support using PCAxis.Serializers v1.2.2

### DIFF
--- a/PxWeb/Code/Api2/Serialization/ParquetSerializer.cs
+++ b/PxWeb/Code/Api2/Serialization/ParquetSerializer.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Http;
+using PCAxis.Paxiom;
+
+namespace PxWeb.Code.Api2.Serialization
+{
+    public class ParquetSerializer : IDataSerializer
+    {
+        public void Serialize(PXModel model, HttpResponse response)
+        {
+            var matrix = model.Meta.Matrix ?? "data";
+
+            response.ContentType = "application/octet-stream";
+            response.Headers.Add("Content-Disposition", $"attachment; filename=\"{matrix}.parquet\"");
+            IPXModelStreamSerializer serializer = new PCAxis.Serializers.ParquetSerializer();
+            serializer.Serialize(model, response.Body);
+        }
+    }
+}

--- a/PxWeb/Code/Api2/Serialization/SerializeManager.cs
+++ b/PxWeb/Code/Api2/Serialization/SerializeManager.cs
@@ -40,6 +40,8 @@ namespace PxWeb.Code.Api2.Serialization
                     return new JsonStatDataSerializer();
                 case "json-stat2":
                     return new JsonStat2DataSerializer();
+                case "parquet":
+                    return new ParquetSerializer();
                 case "html5_table":
                     return new Html5TableDataSerializer();
                 case "relational_table":

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -57,6 +57,7 @@
       "json",
       "json-stat",
       "json-stat2",
+      "parquet",
       "html5_table",
       "relational_table",
       "px"
@@ -89,22 +90,6 @@
         "Period": "10s",
         "Limit": 30
       }
-      //,
-      //{
-      //  "Endpoint": "*",
-      //  "Period": "15m",
-      //  "Limit": 100
-      //},
-      //{
-      //  "Endpoint": "*",
-      //  "Period": "12h",
-      //  "Limit": 1000
-      //},
-      //{
-      //  "Endpoint": "*",
-      //  "Period": "7d",
-      //  "Limit": 10000
-      //}
     ]
   },
 


### PR DESCRIPTION
- Added support for Parquet-format
- Removed comments in appsettings.json as it's not allowed in .json

Can be testet like this: https://localhost:5001/api/v2/tables/TAB004/data?lang=en&outputFormat=parquet