### PR TITLE
Split id-namespace into tableid and folderid

### DIFF
--- a/Px.Abstractions/Interfaces/IDataSource.cs
+++ b/Px.Abstractions/Interfaces/IDataSource.cs
@@ -11,6 +11,15 @@
         /// <returns></returns>
         Item? CreateMenu(string id, string language, out bool selectionExists);
 
+
+        /// <summary>
+        /// Gets a TableLink from the Menu. (This is only usen when Updating the search Index) 
+        /// </summary>
+        /// <param name="id">The "url"-id for the table</param>
+        /// <param name="language"></param>
+        /// <returns>The TableLink data or null if it does not exist</returns>
+        TableLink? CreateMenuTableLink(string id, string language);
+
         /// <summary>
         /// Create builder
         /// </summary>

--- a/Px.Abstractions/Interfaces/IItemSelectionResolver.cs
+++ b/Px.Abstractions/Interfaces/IItemSelectionResolver.cs
@@ -2,6 +2,7 @@
 {
     public interface IItemSelectionResolver
     {
-        ItemSelection Resolve(string language, string selection, out bool selectionExists);
+        ItemSelection ResolveFolder(string language, string selection, out bool selectionExists);
+        ItemSelection ResolveTable(string language, string selection, out bool selectionExists);
     }
 }

--- a/Px.Search/Indexer.cs
+++ b/Px.Search/Indexer.cs
@@ -125,8 +125,6 @@
         /// <param name="languages">list of languages codes that the search index will be able to be searched for</param>
         public void UpdateTableEntries(List<string> tables, List<string> languages)
         {
-            bool exists;
-
             using (var index = _backend.GetIndex())
             {
                 foreach (var language in languages)
@@ -135,11 +133,11 @@
 
                     foreach (var table in tables)
                     {
-                        Item? item = _source.CreateMenu(table, language, out exists);
+                        TableLink? tableLinkItem = _source.CreateMenuTableLink(table, language);
 
-                        if (exists && item != null && item is TableLink)
+                        if (tableLinkItem != null)
                         {
-                            UpdateTable(table, (TableLink)item, language, index);
+                            UpdateTable(table, tableLinkItem, language, index);
                         }
                         else
                         {

--- a/PxWeb.UnitTests/DataSource/CnmmDataSourceTest.cs
+++ b/PxWeb.UnitTests/DataSource/CnmmDataSourceTest.cs
@@ -12,18 +12,18 @@
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupFolders();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupFolders(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverCnmm(memorymock.Object, pcAxisFactory.Object, configMock.Object);
 
             bool selectionExists;
 
-            var result = resolver.Resolve(language, "AA0003", out selectionExists);
+            var result = resolver.ResolveFolder(language, "AA0003", out selectionExists);
 
             Assert.IsNotNull(result);
             Assert.AreEqual("AA", result.Menu);
@@ -40,18 +40,18 @@
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupFolders();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupFolders(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverCnmm(memorymock.Object, pcAxisFactory.Object, configMock.Object);
 
             bool selectionExists;
 
-            var result = resolver.Resolve(language, "", out selectionExists);
+            var result = resolver.ResolveFolder(language, "", out selectionExists);
 
             Assert.AreEqual("START", result.Menu);
             Assert.AreEqual("START", result.Selection);
@@ -72,12 +72,12 @@
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupFolders();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupFolders(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverCnmm(memorymock.Object, pcAxisFactory.Object, configMock.Object);
             var tablePathResolver = new TablePathResolverCnmm(configServiceMock.Object, resolver);
@@ -105,12 +105,12 @@
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupFolders();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupTables(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverCnmm(memorymock.Object, pcAxisFactory.Object, configMock.Object);
             var tablePathResolver = new TablePathResolverCnmm(configServiceMock.Object, resolver);
@@ -136,12 +136,12 @@
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupTables();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupTables(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverCnmm(memorymock.Object, pcAxisFactory.Object, configMock.Object);
             var tablePathResolver = new TablePathResolverCnmm(configServiceMock.Object, resolver);

--- a/PxWeb.UnitTests/DataSource/PXDataSourceTest.cs
+++ b/PxWeb.UnitTests/DataSource/PXDataSourceTest.cs
@@ -32,18 +32,18 @@ namespace PxWeb.UnitTests.DataSource
             var pcAxisFactory = new Mock<IItemSelectionResolverFactory>();
 
             var testFactory = new TestFactory();
-            var dict = testFactory.GetMenuLookup();
+            var dict = testFactory.GetMenuLookupFolders();
 
             var config = testFactory.GetPxApiConfiguration();
             configMock.Setup(x => x.GetConfiguration()).Returns(config);
 
-            pcAxisFactory.Setup(x => x.GetMenuLookup(language)).Returns(dict);
+            pcAxisFactory.Setup(x => x.GetMenuLookupFolders(language)).Returns(dict);
 
             var resolver = new ItemSelectionResolverPxFile(memorymock.Object, pcAxisFactory.Object, configMock.Object);
 
             bool selectionExists;
 
-            var result = resolver.Resolve(language, "", out selectionExists);
+            var result = resolver.ResolveFolder(language, "", out selectionExists);
 
             Assert.AreEqual("START", result.Menu);
             Assert.AreEqual("START", result.Selection);
@@ -115,7 +115,7 @@ namespace PxWeb.UnitTests.DataSource
 
             bool selectionExists;
 
-            var result = resolver.Resolve(language, "EN", out selectionExists);
+            var result = resolver.ResolveFolder(language, "EN", out selectionExists);
 
             Assert.IsNotNull(result);
             Assert.AreEqual("Database", result.Menu);

--- a/PxWeb.UnitTests/TestFactory.cs
+++ b/PxWeb.UnitTests/TestFactory.cs
@@ -5,7 +5,18 @@ namespace PxWeb.UnitTests
     [TestClass]
     public class TestFactory
     {
-        public Dictionary<string, ItemSelection> GetMenuLookup()
+        public Dictionary<string, ItemSelection> GetMenuLookupFolders()
+        {
+            var dict = new Dictionary<string, ItemSelection>();
+
+            dict.Add("AA0003", new ItemSelection("AA", "AA0003"));
+            dict.Add("AA0005", new ItemSelection("AA", "AA0005"));
+            dict.Add("AA0003B", new ItemSelection("AA0003", "AA0003B"));
+            return dict;
+        }
+
+
+        public Dictionary<string, ItemSelection> GetMenuLookupTables()
         {
             var dict = new Dictionary<string, ItemSelection>();
 

--- a/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
@@ -43,18 +43,42 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             }
         }
 
+
+        public TableLink? CreateMenuTableLink(string id, string language)
+        {
+            ItemSelection itmSel = _itemSelectionResolver.ResolveTable(language, id, out bool selectionExists);
+            if (!selectionExists)
+            {
+                return null;
+            }
+
+            Item? outItem = CreateMenu(language, itmSel);
+
+            return (TableLink?)outItem;
+        }
+
         public Item? CreateMenu(string id, string language, out bool selectionExists)
+        {
+            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
+            if (!selectionExists)
+            {
+                return null;
+            }
+
+            Item? outItem = CreateMenu(language, itmSel);
+
+            return outItem;
+
+        }
+
+        private Item? CreateMenu(string language, ItemSelection itmSel)
         {
             var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
 
-            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
-
             TableLink? tblFix = null;
-
-            if (selectionExists)
-            {
-                //Create database object to return
-                DatamodelMenu retMenu = ConfigDatamodelMenu.Create(
+            
+            //Create database object to return
+            DatamodelMenu retMenu = ConfigDatamodelMenu.Create(
                     language,
                     PCAxis.Sql.DbConfig.SqlDbConfigsStatic.DataBases[cnmmOptions.DatabaseID],
                     m =>
@@ -73,7 +97,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 
                                 tbl.Text = CreateTableTitleWithInterval(tbl);
 
-                                if (string.Compare(tbl.ID.Selection, id, true) == 0)
+                                if (string.Compare(tbl.ID.Selection, itmSel.Selection, true) == 0   
+                                 && string.Compare(tbl.ID.Menu, itmSel.Menu, true) == 0)
                                 {
                                     tblFix = tbl;
                                 }
@@ -95,10 +120,12 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                     });
                 retMenu.RootItem.Sort();
 
-                return retMenu.CurrentItem;
-                //return tblFix != null ? tblFix : retMenu.CurrentItem;
-            }
-            return null;
+                var lala1 = tblFix;
+                var lala2 = retMenu.CurrentItem;
+
+                //return retMenu.CurrentItem;
+                return tblFix != null ? tblFix : retMenu.CurrentItem;
+            
         }
 
         public Codelist? GetCodelist(string id, string language)

--- a/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
@@ -76,7 +76,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
 
             TableLink? tblFix = null;
-            
+
             //Create database object to return
             DatamodelMenu retMenu = ConfigDatamodelMenu.Create(
                     language,
@@ -97,7 +97,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 
                                 tbl.Text = CreateTableTitleWithInterval(tbl);
 
-                                if (string.Compare(tbl.ID.Selection, itmSel.Selection, true) == 0   
+                                if (string.Compare(tbl.ID.Selection, itmSel.Selection, true) == 0
                                  && string.Compare(tbl.ID.Menu, itmSel.Menu, true) == 0)
                                 {
                                     tblFix = tbl;
@@ -118,14 +118,10 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         };
                         m.Restriction = item => { return true; }; // TODO: Will show all tables! Even though they are not published...
                     });
-                retMenu.RootItem.Sort();
+            retMenu.RootItem.Sort();
 
-                var lala1 = tblFix;
-                var lala2 = retMenu.CurrentItem;
+            return tblFix != null ? tblFix : retMenu.CurrentItem;
 
-                //return retMenu.CurrentItem;
-                return tblFix != null ? tblFix : retMenu.CurrentItem;
-            
         }
 
         public Codelist? GetCodelist(string id, string language)

--- a/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
@@ -47,7 +47,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
         {
             var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
 
-            ItemSelection itmSel = _itemSelectionResolver.Resolve(language, id, out selectionExists);
+            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
+
             TableLink? tblFix = null;
 
             if (selectionExists)
@@ -93,7 +94,10 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         m.Restriction = item => { return true; }; // TODO: Will show all tables! Even though they are not published...
                     });
                 retMenu.RootItem.Sort();
-                return tblFix != null ? tblFix : retMenu.CurrentItem;
+                var lala = retMenu.GetAsXML();
+
+                return retMenu.CurrentItem;
+                //return tblFix != null ? tblFix : retMenu.CurrentItem;
             }
             return null;
         }
@@ -123,7 +127,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
         {
             bool selectionExists;
 
-            _itemSelectionResolver.Resolve(language, tableId, out selectionExists);
+            _itemSelectionResolver.ResolveTable(language, tableId, out selectionExists);
             return selectionExists;
         }
 

--- a/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/CnmmDataSource.cs
@@ -94,7 +94,6 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         m.Restriction = item => { return true; }; // TODO: Will show all tables! Even though they are not published...
                     });
                 retMenu.RootItem.Sort();
-                var lala = retMenu.GetAsXML();
 
                 return retMenu.CurrentItem;
                 //return tblFix != null ? tblFix : retMenu.CurrentItem;

--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -19,16 +19,46 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             _pxApiConfigurationService = pxApiConfigurationService;
         }
 
-        public ItemSelection Resolve(string language, string selection, out bool selectionExists)
+        public ItemSelection ResolveFolder(string language, string selection, out bool selectionExists)
         {
             selectionExists = true;
             ItemSelection itemSelection = new ItemSelection();
 
-            string lookupTableName = "LookUpTableCache_" + language;
+            string lookupTableName = "LookUpTableCache_Folder" + language;
             var lookupTable = _pxCache.Get<Dictionary<string, ItemSelection>>(lookupTableName);
             if (lookupTable is null)
             {
-                lookupTable = _itemSelectionResolverFactory.GetMenuLookup(language);
+                lookupTable = _itemSelectionResolverFactory.GetMenuLookupFolders(language);
+                _pxCache.Set(lookupTableName, lookupTable);
+            }
+
+            if (!string.IsNullOrEmpty(selection))
+            {
+                if (lookupTable.ContainsKey(selection.ToUpper()))
+                {
+                    var itmSel = lookupTable[selection.ToUpper()];
+                    itemSelection.Menu = itmSel.Menu;
+                    itemSelection.Selection = itmSel.Selection;
+                }
+                else
+                {
+                    selectionExists = false;
+                }
+            }
+            return itemSelection;
+        }
+
+
+        public ItemSelection ResolveTable(string language, string selection, out bool selectionExists)
+        {
+            selectionExists = true;
+            ItemSelection itemSelection = new ItemSelection();
+
+            string lookupTableName = "LookUpTableCache_Table_" + language;
+            var lookupTable = _pxCache.Get<Dictionary<string, ItemSelection>>(lookupTableName);
+            if (lookupTable is null)
+            {
+                lookupTable = _itemSelectionResolverFactory.GetMenuLookupTables(language);
                 _pxCache.Set(lookupTableName, lookupTable);
             }
 

--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -8,6 +8,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 {
     public class ItemSelectionResolverCnmm : IItemSelectionResolver
     {
+        //TODO this class and ItemSelectionResolverPxFile are the same except for name and namespace 
+
         private readonly IPxCache _pxCache;
         private readonly IItemSelectionResolverFactory _itemSelectionResolverFactory;
         private readonly IPxApiConfigurationService _pxApiConfigurationService;

--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmmFactory.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmmFactory.cs
@@ -18,14 +18,24 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             _configOptions = configOptions;
         }
 
-        public Dictionary<string, ItemSelection> GetMenuLookup(string language)
+        public Dictionary<string, ItemSelection> GetMenuLookupFolders(string language)
         {
             var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
             if (!SqlDbConfigsStatic.DataBases.ContainsKey(cnmmOptions.DatabaseID))
             {
                 throw new PXException($"Database with id {cnmmOptions.DatabaseID} not found");
             }
-            return SqlDbConfigsStatic.DataBases[cnmmOptions.DatabaseID].GetMenuLookup(language, _configOptions) ?? new Dictionary<string, ItemSelection>();
+            return SqlDbConfigsStatic.DataBases[cnmmOptions.DatabaseID].GetMenuLookupFolders(language, _configOptions) ?? new Dictionary<string, ItemSelection>();
+        }
+
+        public Dictionary<string, ItemSelection> GetMenuLookupTables(string language)
+        {
+            var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
+            if (!SqlDbConfigsStatic.DataBases.ContainsKey(cnmmOptions.DatabaseID))
+            {
+                throw new PXException($"Database with id {cnmmOptions.DatabaseID} not found");
+            }
+            return SqlDbConfigsStatic.DataBases[cnmmOptions.DatabaseID].GetMenuLookupTables(language, _configOptions) ?? new Dictionary<string, ItemSelection>();
         }
     }
 }

--- a/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
@@ -12,7 +12,17 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 {
     public static class SqlDbConfigExtensions
     {
-        public static Dictionary<string, ItemSelection>? GetMenuLookup(this SqlDbConfig DB, string language, IOptions<PxApiConfigurationOptions> configOptions)
+        public static Dictionary<string, ItemSelection>? GetMenuLookupTables(this SqlDbConfig DB, string language, IOptions<PxApiConfigurationOptions> configOptions)
+        {
+            return GetMenuLookup(DB, language, false, configOptions);
+        }
+        public static Dictionary<string, ItemSelection>? GetMenuLookupFolders(this SqlDbConfig DB, string language, IOptions<PxApiConfigurationOptions> configOptions)
+        {
+            return GetMenuLookup(DB, language, true, configOptions);
+        }
+
+
+        private static Dictionary<string, ItemSelection>? GetMenuLookup(this SqlDbConfig DB, string language, bool folders, IOptions<PxApiConfigurationOptions> configOptions)
         {
             // Check language to avoid SQL injection
             if (!configOptions.Value.Languages.Any(l => l.Id == language))
@@ -25,19 +35,47 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             string sql;
             if (DB is SqlDbConfig_21 sqlDbConfig_21)
             {
-                sql = GetMenuLookupQuery2_1(sqlDbConfig_21, language);
+                if (folders)
+                {
+                    sql = GetMenuLookupFoldersQuery2_1(sqlDbConfig_21, language);
+                }
+                else
+                {
+                    sql = GetMenuLookupTablesQuery2_1(sqlDbConfig_21, language);
+                }
             }
             else if (DB is SqlDbConfig_22 sqlDbConfig_22)
             {
-                sql = sqlDbConfig_22.GetMenuLookupQuery2_2(language);
+                if (folders)
+                {
+                    sql = GetMenuLookupFoldersQuery2_2(sqlDbConfig_22, language);
+                }
+                else
+                {
+                    sql = GetMenuLookupTablesQuery2_2(sqlDbConfig_22, language);
+                }
             }
             else if (DB is SqlDbConfig_23 sqlDbConfig_23)
             {
-                sql = sqlDbConfig_23.GetMenuLookupQuery2_3(language);
+                if (folders)
+                {
+                    sql = GetMenuLookupFoldersQuery2_3(sqlDbConfig_23, language);
+                }
+                else
+                {
+                    sql = GetMenuLookupTablesQuery2_3(sqlDbConfig_23, language);
+                }
             }
             else if (DB is SqlDbConfig_24 sqlDbConfig_24)
             {
-                sql = sqlDbConfig_24.GetMenuLookupQuery2_4(language);
+                if (folders)
+                {
+                    sql = GetMenuLookupFoldersQuery2_4(sqlDbConfig_24, language);
+                }
+                else
+                {
+                    sql = GetMenuLookupTablesQuery2_4(sqlDbConfig_24, language);
+                }
             }
             else
             {
@@ -76,7 +114,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             return menuLookup;
         }
 
-        private static string GetMenuLookupQuery2_1(SqlDbConfig_21 DB, string language)
+        private static string GetMenuLookupFoldersQuery2_1(SqlDbConfig_21 DB, string language)
         {
             if (!DB.isSecondaryLanguage(language))
             {
@@ -87,15 +125,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels') 
-                        UNION
-                        SELECT 
-                            {DB.MenuSelection.MenuCol.ForSelect()}, 
-                            {DB.MainTable.MainTableCol.ForSelect()}, 
-                            {DB.MainTable.TableIdCol.ForSelect()} 
-                        FROM 
-                            {DB.MainTable.GetNameAndAlias()} 
-                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
             }
             else
             {
@@ -107,9 +137,25 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                         JOIN {DB.MenuSelectionLang2.GetNameAndAlias(language)} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                     WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')
-                    UNION
-                    SELECT 
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+            }
+        }
+
+        private static string GetMenuLookupTablesQuery2_1(SqlDbConfig_21 DB, string language)
+        {
+            if (!DB.isSecondaryLanguage(language))
+            {
+                return $@"SELECT 
+                            {DB.MenuSelection.MenuCol.ForSelect()}, 
+                            {DB.MainTable.MainTableCol.ForSelect()}, 
+                            {DB.MainTable.TableIdCol.ForSelect()} 
+                        FROM 
+                            {DB.MainTable.GetNameAndAlias()} 
+                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+            }
+            else
+            {
+                return $@"SELECT 
                             {DB.MenuSelection.MenuCol.ForSelect()}, 
                             {DB.MainTable.MainTableCol.ForSelect()}, 
                             {DB.MainTable.TableIdCol.ForSelect()} 
@@ -122,7 +168,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             }
         }
 
-        private static string GetMenuLookupQuery2_2(this SqlDbConfig_22 DB, string language)
+
+        private static string GetMenuLookupFoldersQuery2_2(this SqlDbConfig_22 DB, string language)
         {
             if (!DB.isSecondaryLanguage(language))
             {
@@ -133,15 +180,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels') 
-                        UNION
-                        SELECT 
-                            {DB.MenuSelection.MenuCol.ForSelect()}, 
-                            {DB.MainTable.MainTableCol.ForSelect()}, 
-                            {DB.MainTable.TableIdCol.ForSelect()} 
-                        FROM 
-                            {DB.MainTable.GetNameAndAlias()} 
-                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
             }
             else
             {
@@ -153,9 +192,25 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                         JOIN {DB.MenuSelectionLang2.GetNameAndAlias(language)} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                     WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')
-                    UNION
-                    SELECT 
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+            }
+        }
+
+        private static string GetMenuLookupTablesQuery2_2(this SqlDbConfig_22 DB, string language)
+        {
+            if (!DB.isSecondaryLanguage(language))
+            {
+                return $@"SELECT 
+                            {DB.MenuSelection.MenuCol.ForSelect()}, 
+                            {DB.MainTable.MainTableCol.ForSelect()}, 
+                            {DB.MainTable.TableIdCol.ForSelect()} 
+                        FROM 
+                            {DB.MainTable.GetNameAndAlias()} 
+                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+            }
+            else
+            {
+                return $@"SELECT 
                             {DB.MenuSelection.MenuCol.ForSelect()}, 
                             {DB.MainTable.MainTableCol.ForSelect()}, 
                             {DB.MainTable.TableIdCol.ForSelect()} 
@@ -168,7 +223,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             }
         }
 
-        private static string GetMenuLookupQuery2_3(this SqlDbConfig_23 DB, string language)
+        private static string GetMenuLookupFoldersQuery2_3(this SqlDbConfig_23 DB, string language)
         {
             if (!DB.isSecondaryLanguage(language))
             {
@@ -179,15 +234,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels') 
-                        UNION
-                        SELECT 
-                            {DB.MenuSelection.MenuCol.ForSelect()}, 
-                            {DB.MainTable.MainTableCol.ForSelect()}, 
-                            {DB.MainTable.TableIdCol.ForSelect()} 
-                        FROM 
-                            {DB.MainTable.GetNameAndAlias()} 
-                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
             }
             else
             {
@@ -199,9 +246,25 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                             JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')
-                        UNION
-                        SELECT 
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+            }
+        }
+
+        private static string GetMenuLookupTablesQuery2_3(this SqlDbConfig_23 DB, string language)
+        {
+            if (!DB.isSecondaryLanguage(language))
+            {
+                return $@"SELECT 
+                            {DB.MenuSelection.MenuCol.ForSelect()}, 
+                            {DB.MainTable.MainTableCol.ForSelect()}, 
+                            {DB.MainTable.TableIdCol.ForSelect()} 
+                        FROM 
+                            {DB.MainTable.GetNameAndAlias()} 
+                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+            }
+            else
+            {
+                return $@"SELECT 
                             {DB.MenuSelection.MenuCol.ForSelect()}, 
                             {DB.MainTable.MainTableCol.ForSelect()}, 
                             {DB.MainTable.TableIdCol.ForSelect()} 
@@ -215,7 +278,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             }
         }
 
-        private static string GetMenuLookupQuery2_4(this SqlDbConfig_24 DB, string language)
+        private static string GetMenuLookupFoldersQuery2_4(this SqlDbConfig_24 DB, string language)
         {
             if (!DB.isSecondaryLanguage(language))
             {
@@ -226,15 +289,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels') 
-                        UNION
-                        SELECT 
-                            {DB.MenuSelection.MenuCol.ForSelect()}, 
-                            {DB.MainTable.MainTableCol.ForSelect()}, 
-                            {DB.MainTable.TableIdCol.ForSelect()} 
-                        FROM 
-                            {DB.MainTable.GetNameAndAlias()} 
-                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
             else
             {
@@ -246,9 +301,27 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                             JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')
-                        UNION
-                        SELECT 
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
+            }
+
+        }
+
+
+        private static string GetMenuLookupTablesQuery2_4(this SqlDbConfig_24 DB, string language)
+        {
+            if (!DB.isSecondaryLanguage(language))
+            {
+                return $@"SELECT 
+                            {DB.MenuSelection.MenuCol.ForSelect()}, 
+                            {DB.MainTable.MainTableCol.ForSelect()}, 
+                            {DB.MainTable.TableIdCol.ForSelect()} 
+                        FROM 
+                            {DB.MainTable.GetNameAndAlias()} 
+                            JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelection.SelectionCol.Id()} = {DB.MainTable.MainTableCol.Id()}";
+            }
+            else
+            {
+                return $@"SELECT 
                             {DB.MenuSelection.MenuCol.ForSelect()}, 
                             {DB.MainTable.MainTableCol.ForSelect()}, 
                             {DB.MainTable.TableIdCol.ForSelect()} 
@@ -262,7 +335,6 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             }
 
         }
-
 
         public static PxSqlCommand GetPxSqlCommand(SqlDbConfig DB)
         {

--- a/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
@@ -125,7 +125,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
             else
             {
@@ -137,7 +137,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                         JOIN {DB.MenuSelectionLang2.GetNameAndAlias(language)} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                     WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
         }
 
@@ -180,7 +180,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
             else
             {
@@ -192,7 +192,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                         JOIN {DB.MenuSelectionLang2.GetNameAndAlias(language)} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                     WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
         }
 
@@ -234,7 +234,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                         FROM 
                             {DB.MenuSelection.GetNameAndAlias()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
             else
             {
@@ -246,7 +246,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                             {DB.MenuSelectionLang2.GetNameAndAlias(language)} 
                             JOIN {DB.MenuSelection.GetNameAndAlias()} ON {DB.MenuSelectionLang2.MenuCol.Id(language)} = {DB.MenuSelection.MenuCol.Id()} AND {DB.MenuSelectionLang2.SelectionCol.Id(language)} = {DB.MenuSelection.SelectionCol.Id()}
                         WHERE 
-                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE {DB.MetaAdm.PropertyCol.Id()} = 'MenuLevels')";
+                            {DB.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {DB.MetaAdm.ValueCol.Id()} FROM {DB.MetaAdm.GetNameAndAlias()} WHERE upper({DB.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
         }
 

--- a/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/SqlDbConfigExtensions.cs
@@ -105,7 +105,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                 }
             }
 
-            if (!menuLookup.ContainsKey("START"))
+            if (folders && !menuLookup.ContainsKey("START"))
             {
                 itemSelection = new ItemSelection("START", "START");
                 menuLookup.Add("START", itemSelection);

--- a/PxWeb/Code/Api2/DataSource/Cnmm/TablePathResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/TablePathResolverCnmm.cs
@@ -18,7 +18,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
         public string Resolve(string language, string id, out bool selectionExists)
         {
             var cnmmOptions = _cnmmConfigurationService.GetConfiguration();
-            ItemSelection itmSel = _itemSelectionResolver.Resolve(language, id, out selectionExists);
+            ItemSelection itmSel = _itemSelectionResolver.ResolveTable(language, id, out selectionExists);
             string path = "";
 
             if (selectionExists)

--- a/PxWeb/Code/Api2/DataSource/IItemSelectionResolverFactory.cs
+++ b/PxWeb/Code/Api2/DataSource/IItemSelectionResolverFactory.cs
@@ -4,6 +4,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 {
     public interface IItemSelectionResolverFactory
     {
-        Dictionary<string, ItemSelection> GetMenuLookup(string language);
+        Dictionary<string, ItemSelection> GetMenuLookupTables(string language);
+
+        Dictionary<string, ItemSelection> GetMenuLookupFolders(string language);
     }
 }

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
@@ -20,17 +20,47 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
             _itemSelectionResolverFactory = itemSelectionResolverFactory;
             _pxApiConfigurationService = pxApiConfigurationService;
         }
-        public ItemSelection Resolve(string language, string selection, out bool selectionExists)
+        public ItemSelection ResolveFolder(string language, string selection, out bool selectionExists)
         {
 
             selectionExists = true;
             ItemSelection itemSelection = new ItemSelection();
 
-            string lookupTableName = "LookUpTableCache_" + language;
+            string lookupTableName = "LookUpTableCache_Folder_" + language;
             var lookupTable = _pxCache.Get<Dictionary<string, ItemSelection>>(lookupTableName);
             if (lookupTable is null)
             {
-                lookupTable = _itemSelectionResolverFactory.GetMenuLookup(language);
+                lookupTable = _itemSelectionResolverFactory.GetMenuLookupFolders(language);
+                _pxCache.Set(lookupTableName, lookupTable);
+            }
+
+            if (!string.IsNullOrEmpty(selection))
+            {
+                if (lookupTable.ContainsKey(selection.ToUpper()))
+                {
+                    var itmSel = lookupTable[selection.ToUpper()];
+                    itemSelection.Menu = itmSel.Menu;
+                    itemSelection.Selection = itmSel.Selection;
+                }
+                else
+                {
+                    selectionExists = false;
+                }
+            }
+            return itemSelection;
+        }
+
+        public ItemSelection ResolveTable(string language, string selection, out bool selectionExists)
+        {
+
+            selectionExists = true;
+            ItemSelection itemSelection = new ItemSelection();
+
+            string lookupTableName = "LookUpTableCache_Table_" + language;
+            var lookupTable = _pxCache.Get<Dictionary<string, ItemSelection>>(lookupTableName);
+            if (lookupTable is null)
+            {
+                lookupTable = _itemSelectionResolverFactory.GetMenuLookupTables(language);
                 _pxCache.Set(lookupTableName, lookupTable);
             }
 

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectorResolverPxFactory.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectorResolverPxFactory.cs
@@ -24,7 +24,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
             _logger = logger;
         }
 
-        public Dictionary<string, ItemSelection> GetMenuLookup(string language)
+        public Dictionary<string, ItemSelection> GetMenuLookupFolders(string language)
         {
             var menuLookup = new Dictionary<string, ItemSelection>();
 
@@ -44,10 +44,6 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                 // Add Menu levels to lookup table
                 string xpath = "//MenuItem";
                 AddMenuItemsToMenuLookup(xdoc, menuLookup, xpath);
-
-                // Add Tables to lookup table
-                xpath = "//Link";
-                AddTablesToMenuLookup(xdoc, menuLookup, xpath);
             }
 
             catch (Exception e)
@@ -76,6 +72,37 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                     }
                 }
             }
+        }
+
+
+        public Dictionary<string, ItemSelection> GetMenuLookupTables(string language)
+        {
+            var menuLookup = new Dictionary<string, ItemSelection>();
+
+            if (!LanguageUtil.HasValidLanguageCodePattern(language))
+            {
+                _logger.LogWarning($"Unsupported language: {LanguageUtil.SanitizeLangueCode(language)}");
+                return menuLookup;
+            }
+
+            language = LanguageUtil.SanitizeLangueCode(language);
+
+            try
+            {
+                var menuXmlFile = new MenuXmlFile(_hostingEnvironment);
+                XmlDocument xdoc = menuXmlFile.GetLanguageAsXmlDocument(language);
+
+                // Add Tables to lookup table
+                string xpath = "//Link";
+                AddTablesToMenuLookup(xdoc, menuLookup, xpath);
+            }
+
+            catch (Exception e)
+            {
+                _logger.LogError($"Error loading MenuLookup table for language {LanguageUtil.SanitizeLangueCode(language)}", e);
+            }
+
+            return menuLookup;
         }
 
         private void AddTablesToMenuLookup(XmlDocument xdoc, Dictionary<string, ItemSelection> menuLookup, string xpath)

--- a/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
@@ -63,7 +63,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
             var xNavigator = xmlDocument.CreateNavigator();
             XDocument xDocument = xNavigator != null ? XDocument.Load(xNavigator.ReadSubtree()) : new XDocument();
 
-            ItemSelection itmSel = _itemSelectionResolver.Resolve(language, id, out selectionExists);
+            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
 
             XmlMenu menu = new XmlMenu(xDocument, language,
                     m =>
@@ -120,7 +120,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
         {
             bool selectionExists;
 
-            _itemSelectionResolver.Resolve(language, tableId, out selectionExists);
+            _itemSelectionResolver.ResolveTable(language, tableId, out selectionExists);
             return selectionExists;
 
         }

--- a/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
@@ -54,8 +54,34 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
             }
         }
 
+        public TableLink? CreateMenuTableLink(string id, string language)
+        {
+            ItemSelection itmSel = _itemSelectionResolver.ResolveTable(language, id, out bool selectionExists);
+            if (!selectionExists)
+            {
+                return null;
+            }
+
+            Item? outItem = CreateMenu(language, itmSel);
+
+            return (TableLink?) outItem;
+        }
+
         public Item? CreateMenu(string id, string language, out bool selectionExists)
         {
+            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
+            if (!selectionExists)
+            {
+                return null;
+            }
+
+            Item? outItem = CreateMenu(language, itmSel);
+
+            return outItem;
+
+        }
+
+        private Item? CreateMenu(string language, ItemSelection itmSel) { 
 
             MenuXmlFile menuXmlFile = new MenuXmlFile(_hostingEnvironment);
             XmlDocument xmlDocument = menuXmlFile.GetAsXmlDocument();
@@ -63,7 +89,6 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
             var xNavigator = xmlDocument.CreateNavigator();
             XDocument xDocument = xNavigator != null ? XDocument.Load(xNavigator.ReadSubtree()) : new XDocument();
 
-            ItemSelection itmSel = _itemSelectionResolver.ResolveFolder(language, id, out selectionExists);
 
             XmlMenu menu = new XmlMenu(xDocument, language,
                     m =>
@@ -83,6 +108,8 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                 {
                     if ((item is PxMenuItem) || (item is TableLink))
                     {
+                        //Hmm, doesnt this mean that a TableLink for TAB004  will differ when it is root and in a folder? It that ok?
+                        //Yes, it seems. item.ID.Selection is not used by CreateMenuTableLinnk client.  
                         item.ID.Selection = GetIdentifierWithoutPath(item.ID.Selection);
                     }
                 }

--- a/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
@@ -64,7 +64,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
 
             Item? outItem = CreateMenu(language, itmSel);
 
-            return (TableLink?) outItem;
+            return (TableLink?)outItem;
         }
 
         public Item? CreateMenu(string id, string language, out bool selectionExists)
@@ -81,7 +81,8 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
 
         }
 
-        private Item? CreateMenu(string language, ItemSelection itmSel) { 
+        private Item? CreateMenu(string language, ItemSelection itmSel)
+        {
 
             MenuXmlFile menuXmlFile = new MenuXmlFile(_hostingEnvironment);
             XmlDocument xmlDocument = menuXmlFile.GetAsXmlDocument();


### PR DESCRIPTION
In Statistics Norway we have a folder with id "kpi" and a table with id "KPI".
GetMenuLookup in ItemSelectionResolverFactory  returns a dictionary with upper(id) as key, so it can not contain both the table and the folder.
We therefore need to split this so that there is  one GetMenuLookup for Tables and one for Folders.  
Edit: It turned of the problem was not there, but a bug in the sql feeding the GetMenuLookup. 
before sql bugfix:
kpi -> [kpi,KPI]  which points to a table   (which has id 03013)
after:
kpi -> [if01,kpi] which points to a folder.
   
However, do make it possible to use the same string as an id for both a folder and a table, the GetMenuLookup has to be split.



