### PR TITLE
Global route prefix middleware (#127)

### DIFF
--- a/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
+++ b/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
@@ -15,6 +15,7 @@ namespace PxWeb.Config.Api2
         public int CacheTime { get; set; } = 5;
         public int PageSize { get; set; }
         public string BaseURL { get; set; } = String.Empty;
+        public string RoutePrefix { get; set; } = String.Empty;
         public List<string> OutputFormats { get; set; } = new List<string>();
         public string DefaultOutputFormat { get; set; } = String.Empty;
 

--- a/PxWeb/Controllers/Api2/Admin/CacheController.cs
+++ b/PxWeb/Controllers/Api2/Admin/CacheController.cs
@@ -15,7 +15,7 @@ namespace PxWeb.Controllers.Api2.Admin
         }
 
         [HttpDelete]
-        [Route("/api/v2/admin/cache")]
+        [Route("/admin/cache")]
         public IActionResult Clear()
         {
             _pxCache.Clear();

--- a/PxWeb/Controllers/Api2/Admin/DatabaseController.cs
+++ b/PxWeb/Controllers/Api2/Admin/DatabaseController.cs
@@ -45,7 +45,7 @@ namespace PxWeb.Controllers.Api2.Admin
         }
 
         [HttpPut]
-        [Route("/api/v2/admin/database")]
+        [Route("/admin/database")]
         [SwaggerOperation("Database")]
         [SwaggerResponse(statusCode: 202, description: "Accepted")]
         [SwaggerResponse(statusCode: 401, description: "Unauthorized")]
@@ -109,7 +109,7 @@ namespace PxWeb.Controllers.Api2.Admin
         }
 
         [HttpGet]
-        [Route("/api/v2/admin/database")]
+        [Route("/admin/database")]
         [SwaggerOperation("Database")]
         [SwaggerResponse(statusCode: 200, description: "Success")]
         [SwaggerResponse(statusCode: 401, description: "Unauthorized")]

--- a/PxWeb/Controllers/Api2/Admin/SearchindexController.cs
+++ b/PxWeb/Controllers/Api2/Admin/SearchindexController.cs
@@ -43,7 +43,7 @@ namespace PxWeb.Controllers.Api2.Admin
         /// </summary>
         /// <returns></returns>
         [HttpPost]
-        [Route("/api/v2/admin/searchindex")]
+        [Route("/admin/searchindex")]
         [SwaggerOperation("IndexDatabase")]
         [SwaggerResponse(statusCode: 202, description: "Accepted")]
         [SwaggerResponse(statusCode: 401, description: "Unauthorized")]
@@ -84,7 +84,7 @@ namespace PxWeb.Controllers.Api2.Admin
         /// <param name="tables"></param>
         /// <returns></returns>
         [HttpPatch]
-        [Route("/api/v2/admin/searchindex")]
+        [Route("/admin/searchindex")]
         [SwaggerOperation("IndexDatabase")]
         [SwaggerResponse(statusCode: 202, description: "Accepted")]
         [SwaggerResponse(statusCode: 401, description: "Unauthorized")]
@@ -135,7 +135,7 @@ namespace PxWeb.Controllers.Api2.Admin
         }
 
         [HttpGet]
-        [Route("/api/v2/admin/searchindex")]
+        [Route("/admin/searchindex")]
         [SwaggerOperation("IndexDatabase")]
         [SwaggerResponse(statusCode: 200, description: "Success")]
         [SwaggerResponse(statusCode: 401, description: "Unauthorized")]

--- a/PxWeb/Controllers/Api2/NavigationApiController.cs
+++ b/PxWeb/Controllers/Api2/NavigationApiController.cs
@@ -45,7 +45,7 @@ namespace PxWeb.Controllers.Api2
         /// <summary>
         /// Gets navigation item with the given id.
         /// HttpGet
-        /// Route /api/v2/navigation/{id}
+        /// Route /navigation/{id}
         /// </summary>
         /// <param name="id">Id</param>
         /// <param name="lang">The language if the default is not what you want.</param>
@@ -61,7 +61,7 @@ namespace PxWeb.Controllers.Api2
         /// <summary>
         /// Browse the database structure
         /// HttpGet
-        /// Route /api/v2/navigation
+        /// Route /navigation
         /// </summary>
         /// <param name="lang">The language if the default is not what you want.</param>
         /// <response code="200">Success</response>

--- a/PxWeb/Mappers/LinkCreator.cs
+++ b/PxWeb/Mappers/LinkCreator.cs
@@ -99,6 +99,7 @@ namespace PxWeb.Mappers
             StringBuilder sb = new StringBuilder();
 
             sb.Append(_urlBase);
+            sb.Append("/");
             sb.Append(endpointUrl);
 
             if (showLangParam)
@@ -114,6 +115,7 @@ namespace PxWeb.Mappers
             StringBuilder sb = new StringBuilder();
 
             sb.Append(_urlBase);
+            sb.Append("/");
             sb.Append(endpointUrl);
 
             if (!string.IsNullOrEmpty(query) && showLangParam)

--- a/PxWeb/Middleware/GlobalRoutePrefixMiddleware.cs
+++ b/PxWeb/Middleware/GlobalRoutePrefixMiddleware.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+namespace PxWeb.Middleware
+{
+
+    public class GlobalRoutePrefixMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly string _routePrefix;
+
+        public GlobalRoutePrefixMiddleware(RequestDelegate next, string routePrefix)
+        {
+            _next = next;
+            _routePrefix = routePrefix;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            context.Request.PathBase = new PathString(_routePrefix);
+            await _next(context);
+        }
+    }
+}

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.3.0" />
     <PackageReference Include="PcAxis.Sql" Version="1.2.4" />
-    <PackageReference Include="PxWeb.Api2.Server" Version="0.0.2-alpha.0.38" />
+    <PackageReference Include="PxWeb.Api2.Server" Version="0.0.2-alpha.0.44" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -39,7 +39,8 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2/",
+    "BaseURL": "https://www.pxapi.com/api/v2",
+    "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",
       "xlsx_doublecolumn",

--- a/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
+++ b/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
@@ -39,7 +39,8 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2/",
+    "BaseURL": "https://www.pxapi.com/api/v2",
+    "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",
       "xlsx_doublecolumn",

--- a/PxWebApi.BigTests/ConfigController/test_appsettings.json
+++ b/PxWebApi.BigTests/ConfigController/test_appsettings.json
@@ -40,7 +40,8 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2/",
+    "BaseURL": "https://www.pxapi.com/api/v2",
+    "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",
       "xlsx_doublecolumn",

--- a/PxWebApi.BigTests/TableController/test_appsettings.json
+++ b/PxWebApi.BigTests/TableController/test_appsettings.json
@@ -40,7 +40,8 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2/",
+    "BaseURL": "https://www.pxapi.com/api/v2",
+    "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",
       "xlsx_doublecolumn",


### PR DESCRIPTION
* Create GlobalRoutePrefixMiddleware.cs
* Update Program.cs
* Update appsettings.json
* Update appsettings.Development.json
* Update to .NET 8.0
* Update PxApiConfigurationOptions.cs
* Remove trailing slash in BaseURL
* Update NavigationApiController.cs
* Remove /api/v2 from Routes


---------