### PR TITLE
Added allow all headers on requests

### DIFF
--- a/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
@@ -55,11 +55,11 @@ namespace PxWeb.Code.Api2
                     {
                         if (allowAnyOrigin)
                         {
-                            policy.AllowAnyOrigin();
+                            policy.AllowAnyOrigin().AllowAnyHeader();
                         }
                         else
                         {
-                            policy.WithOrigins(origins);
+                            policy.WithOrigins(origins).AllowAnyHeader();
                         }
                     });
                 });


### PR DESCRIPTION
Allows all HTTP headers so preflight request for PxWeb 2 will pass.

This fix closes #140 