### PR TITLE
Fix misc warnings

### DIFF
--- a/PxWeb/Code/Api2/Cache/CachedResponse.cs
+++ b/PxWeb/Code/Api2/Cache/CachedResponse.cs
@@ -3,9 +3,9 @@
     public class CachedResponse
     {
         public byte[] content { get; set; }
-        public string contentType { get; set; }
+        public string? contentType { get; set; }
         public int responseCode { get; set; }
-        public CachedResponse(byte[] content, string responseType, int responseCode)
+        public CachedResponse(byte[] content, string? responseType, int responseCode)
         {
             this.content = content;
             contentType = responseType;

--- a/PxWeb/Code/Api2/Cache/PxCache.cs
+++ b/PxWeb/Code/Api2/Cache/PxCache.cs
@@ -61,7 +61,12 @@ namespace PxWeb.Code.Api2.Cache
                 }
             }
 
-            return (T)_cache.Get(key);
+            var value = _cache.Get(key);
+            if (value is null)
+            {
+                return default;
+            }
+            return (T)value;
         }
 
         /// <summary>

--- a/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace PxWeb.Code.Api2
         /// <summary>
         /// Extension method to handle CORS configuration
         /// </summary>
-        public static bool ConfigurePxCORS(this IServiceCollection services, WebApplicationBuilder builder, ILogger logger)
+        public static bool ConfigurePxCORS(this IServiceCollection services, WebApplicationBuilder builder)
         {
             bool corsEnbled = false;
 
@@ -22,7 +22,7 @@ namespace PxWeb.Code.Api2
             catch (System.Exception)
             {
                 corsEnbled = false;
-                logger.LogError("Could not read CORS Enabled configuration");
+                Console.WriteLine("Could not read CORS Enabled configuration");
                 return false;
             }
 
@@ -38,7 +38,7 @@ namespace PxWeb.Code.Api2
                 }
                 catch (System.Exception)
                 {
-                    logger.LogError("Could not read CORS origins configuration");
+                    Console.WriteLine("Could not read CORS origins configuration");
                     return false;
                 }
 

--- a/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
@@ -16,7 +16,8 @@ namespace PxWeb.Code.Api2
             try
             {
                 // Read configuration for CORS enabled
-                bool.TryParse(builder.Configuration.GetSection("PxApiConfiguration:Cors:Enabled").Value.Trim(), out corsEnbled);
+                var corsEnabled = builder.Configuration.GetSection("PxApiConfiguration:Cors:Enabled").Value ?? "false";
+                bool.TryParse(corsEnabled.Trim(), out corsEnbled);
             }
             catch (System.Exception)
             {
@@ -32,7 +33,7 @@ namespace PxWeb.Code.Api2
                 try
                 {
                     // Read configuration for CORS origins
-                    var originsConfig = builder.Configuration.GetSection("PxApiConfiguration:Cors:Origins").Value;
+                    var originsConfig = builder.Configuration.GetSection("PxApiConfiguration:Cors:Origins").Value??"";
                     origins = originsConfig.Split(',', System.StringSplitOptions.TrimEntries);
                 }
                 catch (System.Exception)

--- a/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/CorsServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace PxWeb.Code.Api2
 {
@@ -33,7 +32,7 @@ namespace PxWeb.Code.Api2
                 try
                 {
                     // Read configuration for CORS origins
-                    var originsConfig = builder.Configuration.GetSection("PxApiConfiguration:Cors:Origins").Value??"";
+                    var originsConfig = builder.Configuration.GetSection("PxApiConfiguration:Cors:Origins").Value ?? "";
                     origins = originsConfig.Split(',', System.StringSplitOptions.TrimEntries);
                 }
                 catch (System.Exception)

--- a/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace PxWeb.Code.Api2.DataSource
         public static void AddPxDataSource(this IServiceCollection services, WebApplicationBuilder builder)
         {
             var dataSource = builder.Configuration.GetSection("DataSource:DataSourceType");
-                    
+
             if (dataSource.Value != null && dataSource.Value.ToUpper() == "PX")
             {
                 // Px-file data source

--- a/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
@@ -13,8 +13,8 @@ namespace PxWeb.Code.Api2.DataSource
         public static void AddPxDataSource(this IServiceCollection services, WebApplicationBuilder builder)
         {
             var dataSource = builder.Configuration.GetSection("DataSource:DataSourceType");
-
-            if (dataSource.Value.ToUpper() == "PX")
+                    
+            if (dataSource.Value != null && dataSource.Value.ToUpper() == "PX")
             {
                 // Px-file data source
                 builder.Services.AddTransient<IDataSource, PxFileDataSource>();

--- a/PxWeb/Code/Api2/DataSource/PxFile/CustomXPathContext.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/CustomXPathContext.cs
@@ -42,7 +42,9 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                                     System.Xml.XPath.XPathResultType[] argTypes)
         {
             // Return null if none of the functions match name.
+#pragma warning disable CS8603 // Possible null reference return.
             return null;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
 

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
@@ -3,7 +3,6 @@
 using Px.Abstractions.Interfaces;
 
 using PxWeb.Code.Api2.Cache;
-using PxWeb.Code.Api2.DataSource.Cnmm;
 
 namespace PxWeb.Code.Api2.DataSource.PxFile
 {

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectorResolverPxFactory.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectorResolverPxFactory.cs
@@ -7,8 +7,6 @@ using PCAxis.Menu;
 
 using Px.Abstractions.Interfaces;
 
-using PxWeb.Code.Api2.DataSource.Cnmm;
-
 namespace PxWeb.Code.Api2.DataSource.PxFile
 {
     public class ItemSelectorResolverPxFactory : IItemSelectionResolverFactory

--- a/PxWeb/Code/Api2/SearchEngineServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/SearchEngineServiceCollectionExtensions.cs
@@ -11,9 +11,9 @@ namespace PxWeb.Code.Api2
     {
         public static void AddPxSearchEngine(this IServiceCollection services, WebApplicationBuilder builder)
         {
-            var searchEngine = builder.Configuration.GetSection("PxApiConfiguration:SearchEngine");
+            var searchEngine = builder.Configuration.GetSection("PxApiConfiguration:SearchEngine").Value ?? "";
 
-            if (searchEngine.Value.ToUpper() == "LUCENE")
+            if (searchEngine.ToUpper() == "LUCENE")
             {
                 // Lucene search engine
                 builder.Services.AddTransient<ISearchBackend, LuceneBackend>();

--- a/PxWeb/Controllers/Api2/NavigationApiController.cs
+++ b/PxWeb/Controllers/Api2/NavigationApiController.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 using PCAxis.Menu;
 
 using Px.Abstractions.Interfaces;
-using Px.Search;
 
 using PxWeb.Api2.Server.Models;
 using PxWeb.Helper.Api2;

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -292,12 +292,12 @@ namespace PxWeb.Controllers.Api2
             //No variable selection is provided, so we will return the default selection    
             var selection = _selectionHandler.GetSelection(builder, null, out problem);
 
-            if (problem is not null)
+            if (problem is not null || selection is null)
             {
                 return BadRequest(problem);
             }
 
-            //TODO Map selection to SelectionResponse
+            //Map selection to SelectionResponse
             SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, builder.Model.Meta, id, lang);
             return Ok(selectionResponse);
 

--- a/PxWeb/Middleware/CacheMiddleware.cs
+++ b/PxWeb/Middleware/CacheMiddleware.cs
@@ -35,7 +35,7 @@ namespace PxWeb.Middleware
 
                 httpContext.Response.Body = originalStream;
 
-                string contentType = httpContext.Response.ContentType;
+                string? contentType = httpContext.Response.ContentType;
                 int responseCode = httpContext.Response.StatusCode;
                 CachedResponse response = new CachedResponse(body, contentType, responseCode);
                 return response;

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -36,9 +36,6 @@ namespace PxWeb
 {
     public class Program
     {
-        private static ILogger<Program>? _logger;
-        private static readonly ILog _log = LogManager.GetLogger(typeof(Program));
-
         public static void Main(string[] args)
         {
 
@@ -47,12 +44,7 @@ namespace PxWeb
             var builder = WebApplication.CreateBuilder(args);
 
             // Add services to the container.
-            _logger = builder.Logging.Services.BuildServiceProvider().GetRequiredService<ILogger<Program>>();
-            builder.Logging.AddLog4Net();
-
-            _log.Info("Starting!");
-
-
+            Console.WriteLine("Starting!");
 
             // needed to load configuration from appsettings.json
             builder.Services.AddOptions();
@@ -141,7 +133,7 @@ namespace PxWeb
 
 
             // Handle CORS configuration from appsettings.json
-            bool corsEnbled = builder.Services.ConfigurePxCORS(builder, _logger);
+            bool corsEnbled = builder.Services.ConfigurePxCORS(builder);
 
             // Bind the configuration to the PxApiConfigurationOptions class
             var pxApiConfiguration = new PxApiConfigurationOptions();

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -106,7 +106,7 @@ namespace PxWeb
             var langList = builder.Configuration.GetSection("PxApiConfiguration:Languages")
                 .AsEnumerable()
                 .Where(p => p.Value != null && p.Key.ToLower().Contains("id"))
-                .Select(p => p.Value)
+                .Select(p => p.Value??"")
                 .ToList();
 
 

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -3,14 +3,11 @@ using System.Text;
 
 using AspNetCoreRateLimit;
 
-using log4net;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
 using Newtonsoft.Json.Converters;
@@ -98,7 +95,7 @@ namespace PxWeb
             var langList = builder.Configuration.GetSection("PxApiConfiguration:Languages")
                 .AsEnumerable()
                 .Where(p => p.Value != null && p.Key.ToLower().Contains("id"))
-                .Select(p => p.Value??"")
+                .Select(p => p.Value ?? "")
                 .ToList();
 
 

--- a/PxWebApi.BigTests/GlobalUsings.cs
+++ b/PxWebApi.BigTests/GlobalUsings.cs
@@ -1,24 +1,14 @@
-﻿global using AspNetCoreRateLimit;
-
-global using Microsoft.Extensions.Configuration;
+﻿global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 global using Moq;
 
-global using PCAxis.Query;
-
 global using Px.Abstractions.Interfaces;
-global using Px.Search;
-global using Px.Search.Lucene;
-global using Px.Search.Lucene.Config;
 
 global using PxWeb.Code.Api2.Cache;
-global using PxWeb.Code.Api2.DataSelection;
-global using PxWeb.Code.Api2.DataSource.Cnmm;
 global using PxWeb.Code.Api2.DataSource.PxFile;
-global using PxWeb.Code.Api2.Serialization;
 global using PxWeb.Config.Api2;
 global using PxWeb.Mappers;
 


### PR DESCRIPTION
Fixed misc  null warning
Changed the logging to go to standard out instead of the logging framework to fix a warning. Since we should not manually call BuildServiceProvider() since we can end up with duplicate instances of classes in the DI container. 