### PR TITLE
Adjusted to the new rule for appsettings: baseUrl and routePrefix sho…

### DIFF
--- a/PxWeb/Mappers/LinkCreator.cs
+++ b/PxWeb/Mappers/LinkCreator.cs
@@ -19,14 +19,14 @@ namespace PxWeb.Mappers
             last
         }
 
-        private readonly string _urlBase;
+        private readonly string _urlPrefix;
         private readonly string _defaultDataFormat;
         private readonly List<string> _metaFormats = new List<string> { "json-px", "json-stat2" };
         //Could not get the strings cleanly from MetadataOutputFormatType. Anybody?
 
         public LinkCreator(IOptions<PxApiConfigurationOptions> configOptions)
         {
-            _urlBase = configOptions.Value.BaseURL;
+            _urlPrefix = configOptions.Value.BaseURL + configOptions.Value.RoutePrefix;
             _defaultDataFormat = configOptions.Value.DefaultOutputFormat;
         }
         public Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int pagesize, int pageNumber, bool showLangParam = true)
@@ -109,7 +109,7 @@ namespace PxWeb.Mappers
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append(_urlBase);
+            sb.Append(_urlPrefix);
             sb.Append("/");
             sb.Append(endpointUrl);
 
@@ -139,7 +139,7 @@ namespace PxWeb.Mappers
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append(_urlBase);
+            sb.Append(_urlPrefix);
             sb.Append("/");
             sb.Append(endpointUrl);
 

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -39,7 +39,7 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2",
+    "BaseURL": "https://www.pxapi.com",
     "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",

--- a/PxWeb/appsettings.md
+++ b/PxWeb/appsettings.md
@@ -1,0 +1,5 @@
+# fields in appsettings.json
+The fields baseUrl and routePrefix should be
+so that f.x. the url to the config endpoint is baseUrl + routePrefix + "/config"
+Neither should end with a "/". If not empty routePrefix should start with a "/"    
+The baseUrl should hold the scheme (https normally) + the host + on IIS the virutal Path to the application if any.

--- a/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
+++ b/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
@@ -39,7 +39,7 @@
     "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize": 20,
-    "BaseURL": "https://www.pxapi.com/api/v2",
+    "BaseURL": "https://www.pxapi.com",
     "RoutePrefix": "/api/v2",
     "OutputFormats": [
       "xlsx",


### PR DESCRIPTION
Adjusted to the new rule for appsettings: baseUrl and routePrefix should be 
so that the url to the config endpoint is baseUrl + routePrefix + "/config"
Which meant stripping of the  routePrefix  from the baseUrl in appsetting.json

This problably needs to be done in the system that does the replacing in
 appsetting.release.json line
"BaseURL": "#{BASEURL}#",