### PR TITLE
Time sort order to asending

### DIFF
--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -1264,7 +1264,6 @@ namespace PxWeb.Code.Api2.DataSelection
         private string[] GetTimeCodes(Variable variable, int count)
         {
             var lstCodes = variable.Values.TakeLast(count).Select(value => value.Code).ToList();
-            lstCodes.Sort((a, b) => b.CompareTo(a)); // Descending sort
             var codes = lstCodes.ToArray();
 
             return codes;


### PR DESCRIPTION
This change removes the unneccessary descending sorting when getting time periods for default selection 