### PR TITLE
Changed name of a property in settings to EnableAllEndpointsSwaggerUI

### DIFF
--- a/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
+++ b/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
@@ -31,7 +31,7 @@ namespace PxWeb.Config.Api2
         public string RoutePrefix { get; set; } = String.Empty;
         public List<string> OutputFormats { get; set; } = new List<string>();
         public string DefaultOutputFormat { get; set; } = String.Empty;
-        public bool EnableSwaggerUI { get; set; } = false;
+        public bool EnableAllEndpointsSwaggerUI { get; set; } = false;
 
     }
 }

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -153,7 +153,7 @@ namespace PxWeb
             {
                 options.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
                 {
-                    if (!(pxApiConfiguration.EnableSwaggerUI || app.Environment.IsDevelopment()))
+                    if (!(pxApiConfiguration.EnableAllEndpointsSwaggerUI || app.Environment.IsDevelopment()))
                     {
                         Program.LoadFileIntoSwaggerDoc(swaggerDoc, Path.Combine(AppContext.BaseDirectory, "swagger_v2.json"));
 

--- a/PxWeb/appsettings.Release.json
+++ b/PxWeb/appsettings.Release.json
@@ -62,7 +62,7 @@
       "px"
     ],
     "DefaultOutputFormat": "px",
-    "EnableSwaggerUI": false
+    "EnableAllEndpointsSwaggerUI": false
   },
   "LuceneConfiguration": {
     "IndexDirectory": "Database"

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -64,7 +64,7 @@
       "px"
     ],
     "DefaultOutputFormat": "px",
-    "EnableSwaggerUI": false
+    "EnableAllEndpointsSwaggerUI": false
   },
   "LuceneConfiguration": {
     "IndexDirectory": "Database"

--- a/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
+++ b/PxWebApi.BigTests/AdminDatabaseController/test_appsettings.json
@@ -64,7 +64,7 @@
       "px"
     ],
     "DefaultOutputFormat": "px",
-    "EnableSwaggerUI": false
+    "EnableAllEndpointsSwaggerUI": false
   },
   "LuceneConfiguration": {
     "IndexDirectory": "Database"


### PR DESCRIPTION
 Renamed EnableSwaggerUI to EnableAllEndpointsSwaggerUI, since all installations now have swagger and the choice is if all endspoints  and verbs should  be included, or just a few.