### PR TITLE
Misc fixes in the pivot functionallity

### DIFF
--- a/PxWeb.UnitTests/Data/VariablePlacementTests.cs
+++ b/PxWeb.UnitTests/Data/VariablePlacementTests.cs
@@ -1,0 +1,325 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PxWeb.UnitTests.Data
+{
+
+    [TestClass]
+    public class VariablePlacementTests
+    {
+        [TestMethod]
+        public void ShouldReturnNoPreferredPlacementIfPlacemntIsNull()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+            variablesSelection.Palcement = null;
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNull(placement);
+            
+        }
+
+        [TestMethod]
+        public void ShouldReturnNoPreferredPlacementIfPlacemntIsNull2()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+            variablesSelection.Palcement = new VariablePlacementType();
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNull(placement);
+
+        }
+
+        [TestMethod]
+        public void ShouldReturnNoPreferredPlacementIfPlacemntIsEmpty()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+            
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Stub = new List<string>();
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNull(placement);
+
+        }
+
+        [TestMethod]
+        public void ShouldReturnNoPreferredPlacementIfPlacemntVariableDoesNotExist()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("Age");
+            variablesSelection.Palcement.Stub = new List<string>();
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNotNull(problem);
+            Assert.IsNull(placement);
+        }
+
+        [TestMethod]
+        public void ShouldReturnNoPreferredPlacementIfPlacemntVariableIsDouplicated()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("PointOfTime");
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            variablesSelection.Palcement.Stub.Add("PointOfTime");
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNotNull(problem);
+            Assert.IsNull(placement);
+        }
+
+        [TestMethod]
+        public void ShouldNotReturnPreferredPlacementWhenUsingTime()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("TIME");
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            variablesSelection.Palcement.Stub.Add("PointOfTime");
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNotNull(problem);
+            Assert.IsNull(placement);
+        }
+
+        [TestMethod]
+        public void ShouldNotReturnPreferredPlacementWhenSpecifyingTooManyVariables()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("TIME");
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            variablesSelection.Palcement.Stub.Add("Measure");
+            variablesSelection.Palcement.Stub.Add("X");
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNotNull(problem);
+            Assert.IsNull(placement);
+        }
+
+
+        [TestMethod]
+        public void ShouldReturnPreferredPlacementWhenUsingTime()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("TIME");
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            variablesSelection.Palcement.Stub.Add("GENDER");
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNotNull(placement);
+            Assert.AreEqual(placement.Heading.Count, 2);
+        }
+
+        [TestMethod]
+        public void ShouldReturnPreferredPlacementWhenOnlySpecifyingHeading()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            Selection[]? selection = GetSelectionForAllVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNotNull(placement);
+            Assert.AreEqual(placement.Stub.Count, 2);
+        }
+
+        [TestMethod]
+        public void ShouldReturnPreferredPlacementWhenOnlySpecifyingHeadingWithElimination()
+        {
+            // Arrange
+            IPlacementHandler placementHandler = new PlacementHandler();
+            VariablesSelection variablesSelection = new VariablesSelection();
+
+            variablesSelection.Palcement = new VariablePlacementType();
+            variablesSelection.Palcement.Heading = new List<string>();
+            variablesSelection.Palcement.Heading.Add("MEASURE");
+            variablesSelection.Palcement.Stub = new List<string>();
+            Selection[]? selection = GetSelectionForMandantoryVariables();
+            PXMeta meta = ModelStore.CreateModelA().Meta;
+
+            Problem? problem;
+
+            // Act
+            var placement = placementHandler.GetPlacment(variablesSelection,
+                                                         selection,
+                                                         meta,
+                                                         out problem);
+
+            // Assert
+            Assert.IsNull(problem);
+            Assert.IsNotNull(placement);
+            Assert.AreEqual(placement.Stub.Count, 1);
+        }
+
+        private static Selection[] GetSelectionForAllVariables()
+        {
+            var selections = new List<Selection>();
+            var selection = new Selection("PointOfTime");
+            selection.ValueCodes.Add("2000");
+            selection.ValueCodes.Add("2001");
+            selection.ValueCodes.Add("2002");
+            selections.Add(selection);
+            selection = new Selection("Measure");
+            selection.ValueCodes.Add("M1");
+            selections.Add(selection);
+            selection = new Selection("GENDER");
+            selection.ValueCodes.Add("M");
+            selections.Add(selection);
+            return selections.ToArray();
+
+        }
+
+
+        private static Selection[] GetSelectionForMandantoryVariables()
+        {
+            var selections = new List<Selection>();
+            var selection = new Selection("PointOfTime");
+            selection.ValueCodes.Add("2000");
+            selection.ValueCodes.Add("2001");
+            selection.ValueCodes.Add("2002");
+            selections.Add(selection);
+            selection = new Selection("Measure");
+            selection.ValueCodes.Add("M1");
+            selections.Add(selection);
+            selection = new Selection("GENDER");
+            selections.Add(selection);
+            return selections.ToArray();
+        }
+
+
+    }
+}

--- a/PxWeb.UnitTests/Data/VariablePlacementTests.cs
+++ b/PxWeb.UnitTests/Data/VariablePlacementTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace PxWeb.UnitTests.Data
+﻿namespace PxWeb.UnitTests.Data
 {
 
     [TestClass]
@@ -30,7 +24,7 @@ namespace PxWeb.UnitTests.Data
             // Assert
             Assert.IsNull(problem);
             Assert.IsNull(placement);
-            
+
         }
 
         [TestMethod]
@@ -62,7 +56,7 @@ namespace PxWeb.UnitTests.Data
             // Arrange
             IPlacementHandler placementHandler = new PlacementHandler();
             VariablesSelection variablesSelection = new VariablesSelection();
-            
+
             variablesSelection.Palcement = new VariablePlacementType();
             variablesSelection.Palcement.Heading = new List<string>();
             variablesSelection.Palcement.Stub = new List<string>();

--- a/PxWeb.UnitTests/Data/VariablePlacementTests.cs
+++ b/PxWeb.UnitTests/Data/VariablePlacementTests.cs
@@ -220,7 +220,7 @@
             // Assert
             Assert.IsNull(problem);
             Assert.IsNotNull(placement);
-            Assert.AreEqual(placement.Heading.Count, 2);
+            Assert.AreEqual(2, placement.Heading.Count);
         }
 
         [TestMethod]
@@ -248,7 +248,7 @@
             // Assert
             Assert.IsNull(problem);
             Assert.IsNotNull(placement);
-            Assert.AreEqual(placement.Stub.Count, 2);
+            Assert.AreEqual(2, placement.Stub.Count);
         }
 
         [TestMethod]
@@ -276,7 +276,7 @@
             // Assert
             Assert.IsNull(problem);
             Assert.IsNotNull(placement);
-            Assert.AreEqual(placement.Stub.Count, 1);
+            Assert.AreEqual(1, placement.Stub.Count);
         }
 
         private static Selection[] GetSelectionForAllVariables()

--- a/PxWeb.UnitTests/ModelStore.cs
+++ b/PxWeb.UnitTests/ModelStore.cs
@@ -1,7 +1,53 @@
-﻿namespace PxWeb.UnitTests
+﻿using PCAxis.Paxiom.Operations;
+using PCAxis.Paxiom;
+
+namespace PxWeb.UnitTests
 {
     internal static class ModelStore
     {
+
+        public static PXModel CreateModelA()
+        {
+
+            PXModel model = new PXModel();
+            PXMeta meta = new PXMeta();
+
+            // Create time variable
+            var name = "PointOfTime";
+            Variable variable = new Variable(name, PlacementType.Heading);
+
+            for (int i = 1968; i < 2025; i++)
+            {
+                variable.Values.Add(CreateValue($"{i}"));
+            }
+            variable.TimeValue = $"TLIST(A, \"1968\"-\"2025\")";
+            variable.IsTime = true;
+            meta.AddVariable(variable);
+
+            // Create content variable
+            name = $"MEASURE";
+            variable = new Variable(name, PlacementType.Heading);
+            variable.Values.Add(CreateValue($"M1"));
+            variable.Values.Add(CreateValue($"M2"));
+            variable.Elimination = false;
+            variable.IsContentVariable = true;
+            meta.Variables.Add(variable);
+
+            //Create classification variable gender
+            
+            name = "GENDER";
+
+            variable = new Variable(name, PlacementType.Stub);
+            variable.Values.Add(CreateValue($"M"));
+            variable.Values.Add(CreateValue($"F"));
+            variable.Elimination = true;
+            meta.Variables.Add(variable);
+
+            model.Meta = meta;
+            return model;
+        }
+
+
         public static PXModel GetModelWithOnlyOneVariable(int numberOfValues)
         {
 

--- a/PxWeb.UnitTests/ModelStore.cs
+++ b/PxWeb.UnitTests/ModelStore.cs
@@ -1,7 +1,4 @@
-﻿using PCAxis.Paxiom.Operations;
-using PCAxis.Paxiom;
-
-namespace PxWeb.UnitTests
+﻿namespace PxWeb.UnitTests
 {
     internal static class ModelStore
     {
@@ -34,7 +31,7 @@ namespace PxWeb.UnitTests
             meta.Variables.Add(variable);
 
             //Create classification variable gender
-            
+
             name = "GENDER";
 
             variable = new Variable(name, PlacementType.Stub);

--- a/PxWeb/Code/Api2/DataSelection/IPlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/IPlacementHandler.cs
@@ -1,4 +1,5 @@
 ﻿using PCAxis.Paxiom;
+
 using PxWeb.Api2.Server.Models;
 
 namespace PxWeb.Code.Api2.DataSelection

--- a/PxWeb/Code/Api2/DataSelection/IPlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/IPlacementHandler.cs
@@ -1,0 +1,10 @@
+﻿using PCAxis.Paxiom;
+using PxWeb.Api2.Server.Models;
+
+namespace PxWeb.Code.Api2.DataSelection
+{
+    public interface IPlacementHandler
+    {
+        VariablePlacementType? GetPlacment(VariablesSelection variablesSelection, Selection[] selection, PXMeta meta, out Problem? problem);
+    }
+}

--- a/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
@@ -1,7 +1,9 @@
-﻿using PCAxis.Paxiom;
+﻿using System.Linq;
+
+using PCAxis.Paxiom;
+
 using PxWeb.Api2.Server.Models;
 using PxWeb.Helper.Api2;
-using System.Linq;
 
 namespace PxWeb.Code.Api2.DataSelection
 {
@@ -68,7 +70,7 @@ namespace PxWeb.Code.Api2.DataSelection
             }
 
             //Check if user have specified stub or heading
-            if ((p.Heading.Count > 0  && p.Stub.Count == 0) ||
+            if ((p.Heading.Count > 0 && p.Stub.Count == 0) ||
                  p.Heading.Count == 0 && p.Stub.Count > 0)
             {
 
@@ -93,6 +95,6 @@ namespace PxWeb.Code.Api2.DataSelection
             return null;
 
         }
-       
+
     }
 }

--- a/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
@@ -35,12 +35,7 @@ namespace PxWeb.Code.Api2.DataSelection
             }
 
             //Replace the text TIME with tid in list
-            var time = meta.Variables.Find(x => x.IsTime);
-            if (time != null)
-            {
-                p.Stub = p.Stub.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
-                p.Heading = p.Heading.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
-            }
+            ReplaceTimeConstant(meta, p);
 
             var selectedVariablesCode = selection.Where(x => x.ValueCodes.Count > 0).Select(x => x.VariableCode).ToList();
 
@@ -96,5 +91,14 @@ namespace PxWeb.Code.Api2.DataSelection
 
         }
 
+        private static void ReplaceTimeConstant(PXMeta meta, VariablePlacementType? p)
+        {
+            var time = meta.Variables.Find(x => x.IsTime);
+            if (time != null)
+            {
+                p.Stub = p.Stub.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
+                p.Heading = p.Heading.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
+            }
+        }
     }
 }

--- a/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
@@ -40,10 +40,7 @@ namespace PxWeb.Code.Api2.DataSelection
             var selectedVariablesCode = selection.Where(x => x.ValueCodes.Count > 0).Select(x => x.VariableCode).ToList();
 
             //Check if all variables are in the model
-            if (!(p.Stub.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
-                    code.Equals(variableCode, StringComparison.OrdinalIgnoreCase))) &&
-                  p.Heading.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
-                    code.Equals(variableCode, StringComparison.OrdinalIgnoreCase)))))
+            if (!AllVariablesExistsInSelection(p, selectedVariablesCode))
             {
                 problem = ProblemUtility.IllegalPlacementSelection();
                 return null;
@@ -65,8 +62,7 @@ namespace PxWeb.Code.Api2.DataSelection
             }
 
             //Check if user have specified stub or heading
-            if ((p.Heading.Count > 0 && p.Stub.Count == 0) ||
-                 p.Heading.Count == 0 && p.Stub.Count > 0)
+            if (OnlyHeadOrStubIsSpecified(p))
             {
 
                 List<string> usedVariables = new List<string>();
@@ -91,7 +87,21 @@ namespace PxWeb.Code.Api2.DataSelection
 
         }
 
-        private static void ReplaceTimeConstant(PXMeta meta, VariablePlacementType? p)
+        private static bool OnlyHeadOrStubIsSpecified(VariablePlacementType p)
+        {
+            return (p.Heading.Count > 0 && p.Stub.Count == 0) ||
+                             (p.Heading.Count == 0 && p.Stub.Count > 0);
+        }
+
+        private static bool AllVariablesExistsInSelection(VariablePlacementType p, List<string> selectedVariablesCode)
+        {
+            return (p.Stub.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
+                                code.Equals(variableCode, StringComparison.OrdinalIgnoreCase))) &&
+                              p.Heading.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
+                                code.Equals(variableCode, StringComparison.OrdinalIgnoreCase))));
+        }
+
+        private static void ReplaceTimeConstant(PXMeta meta, VariablePlacementType p)
         {
             var time = meta.Variables.Find(x => x.IsTime);
             if (time != null)

--- a/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
@@ -1,0 +1,98 @@
+﻿using PCAxis.Paxiom;
+using PxWeb.Api2.Server.Models;
+using PxWeb.Helper.Api2;
+using System.Linq;
+
+namespace PxWeb.Code.Api2.DataSelection
+{
+    public class PlacementHandler : IPlacementHandler
+    {
+        VariablePlacementType? IPlacementHandler.GetPlacment(VariablesSelection variablesSelection, Selection[] selection, PXMeta meta, out Problem? problem)
+        {
+            var p = variablesSelection.Palcement;
+
+            //No placement is specified
+            if (p is null)
+            {
+                problem = null;
+                return null;
+            }
+
+            //If not placement is specified, return null
+            if (p.Heading is null || p.Stub is null)
+            {
+                problem = null;
+                return null;
+            }
+
+            //If not placement is specified, return null
+            if (p.Heading.Count == 0 && p.Stub.Count == 0)
+            {
+                problem = null;
+                return null;
+            }
+
+            //Replace the text TIME with tid in list
+            var time = meta.Variables.FirstOrDefault(x => x.IsTime);
+            if (time != null)
+            {
+                p.Stub = p.Stub.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
+                p.Heading = p.Heading.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
+            }
+
+            var selectedVariablesCode = selection.Where(x => x.ValueCodes.Count > 0).Select(x => x.VariableCode).ToList();
+
+            //Check if all variables are in the model
+            if (!(p.Stub.All(variableCode => selectedVariablesCode.Exists(code =>
+                    code.Equals(variableCode, StringComparison.OrdinalIgnoreCase))) &&
+                  p.Heading.All(variableCode => selectedVariablesCode.Exists(code =>
+                    code.Equals(variableCode, StringComparison.OrdinalIgnoreCase)))))
+            {
+                problem = ProblemUtility.IllegalPlacementSelection();
+                return null;
+            }
+
+
+            //Check if all variables have a placement
+            if (p.Heading.Count + p.Stub.Count == selectedVariablesCode.Count)
+            {
+                //Check for duplicates
+                if (p.Heading.Intersect(p.Stub).Any())
+                {
+                    problem = ProblemUtility.IllegalPlacementSelection();
+                    return null;
+                }
+
+                problem = null;
+                return p;
+            }
+
+            //Check if user have specified stub or heading
+            if ((p.Heading.Count > 0  && p.Stub.Count == 0) ||
+                 p.Heading.Count == 0 && p.Stub.Count > 0)
+            {
+
+                List<string> usedVariables = new List<string>();
+                usedVariables.AddRange(p.Heading);
+                usedVariables.AddRange(p.Stub);
+                var unusedVariables = selectedVariablesCode.Except(usedVariables, StringComparer.OrdinalIgnoreCase).ToList();
+
+                if (p.Heading.Count == 0)
+                {
+                    problem = null;
+                    return new VariablePlacementType() { Heading = unusedVariables, Stub = p.Stub };
+                }
+                else
+                {
+                    problem = null;
+                    return new VariablePlacementType() { Heading = p.Heading, Stub = unusedVariables };
+                }
+            }
+
+            problem = ProblemUtility.IllegalPlacementSelection();
+            return null;
+
+        }
+       
+    }
+}

--- a/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/PlacementHandler.cs
@@ -35,7 +35,7 @@ namespace PxWeb.Code.Api2.DataSelection
             }
 
             //Replace the text TIME with tid in list
-            var time = meta.Variables.FirstOrDefault(x => x.IsTime);
+            var time = meta.Variables.Find(x => x.IsTime);
             if (time != null)
             {
                 p.Stub = p.Stub.Select(x => x.Equals("TIME", System.StringComparison.OrdinalIgnoreCase) ? time.Code : x).ToList();
@@ -45,9 +45,9 @@ namespace PxWeb.Code.Api2.DataSelection
             var selectedVariablesCode = selection.Where(x => x.ValueCodes.Count > 0).Select(x => x.VariableCode).ToList();
 
             //Check if all variables are in the model
-            if (!(p.Stub.All(variableCode => selectedVariablesCode.Exists(code =>
+            if (!(p.Stub.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
                     code.Equals(variableCode, StringComparison.OrdinalIgnoreCase))) &&
-                  p.Heading.All(variableCode => selectedVariablesCode.Exists(code =>
+                  p.Heading.TrueForAll(variableCode => selectedVariablesCode.Exists(code =>
                     code.Equals(variableCode, StringComparison.OrdinalIgnoreCase)))))
             {
                 problem = ProblemUtility.IllegalPlacementSelection();

--- a/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
+++ b/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
@@ -28,7 +28,7 @@ namespace PxWeb.Code.Api2.ModelBinder
                     if (q != null)
                     {
                         var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))");
-                        
+
                         foreach (var item in items)
                         {
                             var item2 = item.Trim();

--- a/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
+++ b/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace PxWeb.Code.Api2.ModelBinder
+{
+    public class CommaSeparatedStringToListOfStrings : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+
+            if (bindingContext == null)
+                throw new ArgumentNullException(nameof(bindingContext));
+
+            var modelName = bindingContext.ModelName;
+
+            var result = new List<string>();
+
+            var keys = bindingContext.HttpContext.Request.Query.Keys.ToList().Where(x => x.Equals(modelName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+
+            foreach (var key in keys)
+            {
+                if (key != null)
+                {
+                    string? q = bindingContext.HttpContext.Request.Query[key];
+                    if (q != null)
+                    {
+                        var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))");
+                        
+                        foreach (var item in items)
+                        {
+                            var item2 = item.Trim();
+                            if (item.StartsWith("[") && item.EndsWith("]"))
+                            {
+                                result.Add(item.Substring(1, item.Length - 2));
+                            }
+                            else
+                            {
+                                result.Add(item2);
+                            }
+                        }
+                    }
+                }
+            }
+
+
+            bindingContext.Result = ModelBindingResult.Success(result);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
+++ b/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
@@ -18,31 +18,21 @@ namespace PxWeb.Code.Api2.ModelBinder
 
             var result = new List<string>();
 
-            var keys = bindingContext.HttpContext.Request.Query.Keys.ToList().Where(x => x.Equals(modelName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            var keys = bindingContext.HttpContext.Request.Query.Keys.Where(x => x.Equals(modelName, StringComparison.InvariantCultureIgnoreCase));
 
             foreach (var key in keys)
             {
-                if (key != null)
+                string? q = bindingContext.HttpContext.Request.Query[key];
+                if (q != null)
                 {
-                    string? q = bindingContext.HttpContext.Request.Query[key];
-                    if (q != null)
-                    {
-                        var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))", RegexOptions.IgnoreCase,
-                                    TimeSpan.FromMilliseconds(100));
+                    var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))", RegexOptions.IgnoreCase,
+                                TimeSpan.FromMilliseconds(100));
 
-                        foreach (var item in items)
-                        {
-                            var item2 = item.Trim();
-                            if (item.StartsWith("[") && item.EndsWith("]"))
-                            {
-                                result.Add(item.Substring(1, item.Length - 2));
-                            }
-                            else
-                            {
-                                result.Add(item2);
-                            }
-                        }
+                    foreach (var item in items)
+                    {
+                        result.Add(CleanValue(item));
                     }
+
                 }
             }
 
@@ -50,6 +40,17 @@ namespace PxWeb.Code.Api2.ModelBinder
             bindingContext.Result = ModelBindingResult.Success(result);
 
             return Task.CompletedTask;
+        }
+
+        private static string CleanValue(string value)
+        {
+            var item2 = value.Trim();
+            if (item2.StartsWith('[') && item2.EndsWith(']'))
+            {
+                return value.Substring(1, item2.Length - 2);
+            }
+            return item2;
+
         }
     }
 }

--- a/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
+++ b/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
@@ -8,6 +8,7 @@ namespace PxWeb.Code.Api2.ModelBinder
 {
     public class CommaSeparatedStringToListOfStrings : IModelBinder
     {
+
         public Task BindModelAsync(ModelBindingContext bindingContext)
         {
 
@@ -25,14 +26,14 @@ namespace PxWeb.Code.Api2.ModelBinder
                 string? q = bindingContext.HttpContext.Request.Query[key];
                 if (q != null)
                 {
-                    var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))", RegexOptions.IgnoreCase,
-                                TimeSpan.FromMilliseconds(100));
+                    var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))", RegexOptions.None,
+                            TimeSpan.FromMilliseconds(100));
+
 
                     foreach (var item in items)
                     {
                         result.Add(CleanValue(item));
                     }
-
                 }
             }
 
@@ -47,7 +48,7 @@ namespace PxWeb.Code.Api2.ModelBinder
             var item2 = value.Trim();
             if (item2.StartsWith('[') && item2.EndsWith(']'))
             {
-                return value.Substring(1, item2.Length - 2);
+                return value.Substring(1, item2.Length - 2).Trim();
             }
             return item2;
 

--- a/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
+++ b/PxWeb/Code/Api2/ModelBinder/CommaSeparatedStringToListOfStrings.cs
@@ -27,7 +27,8 @@ namespace PxWeb.Code.Api2.ModelBinder
                     string? q = bindingContext.HttpContext.Request.Query[key];
                     if (q != null)
                     {
-                        var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))");
+                        var items = Regex.Split(q, ",(?=[^\\]]*(?:\\[|$))", RegexOptions.IgnoreCase,
+                                    TimeSpan.FromMilliseconds(100));
 
                         foreach (var item in items)
                         {

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -9,6 +9,9 @@
  */
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Net.NetworkInformation;
+
+using DocumentFormat.OpenXml.Office2013.Drawing.Chart;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -24,6 +27,7 @@ using Px.Search;
 
 using PxWeb.Api2.Server.Models;
 using PxWeb.Code.Api2.DataSelection;
+using PxWeb.Code.Api2.ModelBinder;
 using PxWeb.Code.Api2.Serialization;
 using PxWeb.Helper.Api2;
 using PxWeb.Mappers;
@@ -47,9 +51,10 @@ namespace PxWeb.Controllers.Api2
         private readonly ISerializeManager _serializeManager;
         private readonly PxApiConfigurationOptions _configOptions;
         private readonly ISelectionHandler _selectionHandler;
+        private readonly IPlacementHandler _placementHandler;
         private readonly ISelectionResponseMapper _selectionResponseMapper;
 
-        public TableApiController(IDataSource dataSource, ILanguageHelper languageHelper, ITableMetadataResponseMapper responseMapper, IDatasetMapper datasetMapper, ISearchBackend backend, IOptions<PxApiConfigurationOptions> configOptions, ITablesResponseMapper tablesResponseMapper, ITableResponseMapper tableResponseMapper, ICodelistResponseMapper codelistResponseMapper, ISelectionResponseMapper selectionResponseMapper, ISerializeManager serializeManager, ISelectionHandler selectionHandler)
+        public TableApiController(IDataSource dataSource, ILanguageHelper languageHelper, ITableMetadataResponseMapper responseMapper, IDatasetMapper datasetMapper, ISearchBackend backend, IOptions<PxApiConfigurationOptions> configOptions, ITablesResponseMapper tablesResponseMapper, ITableResponseMapper tableResponseMapper, ICodelistResponseMapper codelistResponseMapper, ISelectionResponseMapper selectionResponseMapper, ISerializeManager serializeManager, ISelectionHandler selectionHandler, IPlacementHandler placementHandler)
         {
             _dataSource = dataSource;
             _languageHelper = languageHelper;
@@ -63,6 +68,7 @@ namespace PxWeb.Controllers.Api2
             _serializeManager = serializeManager;
             _selectionHandler = selectionHandler;
             _selectionResponseMapper = selectionResponseMapper;
+            _placementHandler = placementHandler;
         }
 
         public override IActionResult GetMetadataById([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "outputFormat")] MetadataOutputFormatType? outputFormat)
@@ -155,8 +161,8 @@ namespace PxWeb.Controllers.Api2
             return Ok(_tablesResponseMapper.Map(searchResultContainer, lang, query));
 
         }
-
-        public override IActionResult GetTableData([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "valuecodes")] Dictionary<string, List<string>>? valuecodes, [FromQuery(Name = "codelist")] Dictionary<string, string>? codelist, [FromQuery(Name = "outputvalues")] Dictionary<string, CodeListOutputValuesType>? outputvalues, [FromQuery(Name = "outputFormat")] string? outputFormat, [FromQuery(Name = "heading")] List<string>? heading, [FromQuery(Name = "stub")] List<string>? stub)
+        
+        public override IActionResult GetTableData([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "valuecodes"), ModelBinder(typeof(QueryStringToDictionaryOfStrings))] Dictionary<string, List<string>>? valuecodes, [FromQuery(Name = "codelist")] Dictionary<string, string>? codelist, [FromQuery(Name = "outputvalues")] Dictionary<string, CodeListOutputValuesType>? outputvalues, [FromQuery(Name = "outputFormat")] string? outputFormat, [FromQuery(Name = "heading"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? heading, [FromQuery(Name = "stub"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? stub)
         {
             VariablesSelection variablesSelection = MapDataParameters(valuecodes, codelist, outputvalues, heading, stub);
             return GetData(id, lang, variablesSelection, outputFormat);
@@ -200,10 +206,11 @@ namespace PxWeb.Controllers.Api2
                 {
                     selection = _selectionHandler.GetSelection(builder, variablesSelection, out problem);
 
-                    if (problem is not null)
+                    if (problem is null && selection is not null)
                     {
                         //Check if we should pivot the table
-                        placment = GetPlacment(variablesSelection, builder, out problem);
+                        placment = _placementHandler.GetPlacment(variablesSelection, selection, builder.Model.Meta, out problem);
+                        //GetPlacment(variablesSelection, selection, builder, out problem);
                     }
                 }
             }
@@ -223,7 +230,7 @@ namespace PxWeb.Controllers.Api2
 
                 descriptions.AddRange(placment.Heading.Select(h => new PivotDescription()
                 {
-                    VariableName = model.Meta.Variables.First(v => v.Code == h).Name,
+                    VariableName = model.Meta.Variables.First(v => v.Code.Equals(h, StringComparison.OrdinalIgnoreCase)).Name,
                     VariablePlacement = PlacementType.Heading
                 }));
 
@@ -252,51 +259,7 @@ namespace PxWeb.Controllers.Api2
             return Ok();
         }
 
-
-        private VariablePlacementType? GetPlacment(VariablesSelection variablesSelection, IPXModelBuilder builder, out Problem? problem)
-        {
-            VariablePlacementType? placment = null;
-            var p = variablesSelection.Palcement;
-            //Check if user have specified stub or heading
-            if (p is not null && (p.Heading.Count > 0 || p.Stub.Count > 0))
-            {
-                if ((p.Heading.Count + p.Stub.Count) != builder.Model.Meta.Variables.Count)
-                {
-                    //Check if only one variable is selected
-                    if (p.Heading.Count == 0 || p.Stub.Count == 0)
-                    {
-                        List<string> usedVariables = new List<string>();
-                        usedVariables.AddRange(p.Heading);
-                        usedVariables.AddRange(p.Stub);
-
-                        var unusedVariables = builder.Model.Meta.Variables.Select(v => v.Code).Except(usedVariables).ToList();
-
-                        if (p.Heading.Count == 0)
-                        {
-                            placment = new VariablePlacementType() { Heading = unusedVariables, Stub = p.Stub };
-                        }
-                        else
-                        {
-                            placment = new VariablePlacementType() { Heading = p.Heading, Stub = unusedVariables };
-                        }
-                    }
-                    else
-                    {
-                        //Not all variables are specified in placment
-                        problem = ProblemUtility.IllegalSelection();
-                        return null;
-                    }
-                }
-                else
-                {
-                    placment = p;
-                }
-            }
-
-            problem = null;
-            return placment;
-        }
-
+        
 
         /// <summary>
         /// Map querystring parameters to VariablesSelection object
@@ -304,6 +267,8 @@ namespace PxWeb.Controllers.Api2
         /// <param name="valuecodes"></param>
         /// <param name="codelist"></param>
         /// <param name="outputvalues"></param>
+        /// <param name="heading"></param>
+        /// <param name="stub"></param> 
         /// <returns></returns>
         private VariablesSelection MapDataParameters(Dictionary<string, List<string>>? valuecodes, Dictionary<string, string>? codelist, Dictionary<string, CodeListOutputValuesType>? outputvalues, List<string>? heading, List<string>? stub)
         {

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -9,9 +9,6 @@
  */
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Net.NetworkInformation;
-
-using DocumentFormat.OpenXml.Office2013.Drawing.Chart;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -161,7 +158,7 @@ namespace PxWeb.Controllers.Api2
             return Ok(_tablesResponseMapper.Map(searchResultContainer, lang, query));
 
         }
-        
+
         public override IActionResult GetTableData([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "valuecodes"), ModelBinder(typeof(QueryStringToDictionaryOfStrings))] Dictionary<string, List<string>>? valuecodes, [FromQuery(Name = "codelist")] Dictionary<string, string>? codelist, [FromQuery(Name = "outputvalues")] Dictionary<string, CodeListOutputValuesType>? outputvalues, [FromQuery(Name = "outputFormat")] string? outputFormat, [FromQuery(Name = "heading"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? heading, [FromQuery(Name = "stub"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? stub)
         {
             VariablesSelection variablesSelection = MapDataParameters(valuecodes, codelist, outputvalues, heading, stub);
@@ -259,7 +256,7 @@ namespace PxWeb.Controllers.Api2
             return Ok();
         }
 
-        
+
 
         /// <summary>
         /// Map querystring parameters to VariablesSelection object

--- a/PxWeb/Helper/Api2/ProblemUtility.cs
+++ b/PxWeb/Helper/Api2/ProblemUtility.cs
@@ -57,6 +57,15 @@ namespace PxWeb.Helper.Api2
             return p;
         }
 
+        public static Problem IllegalPlacementSelection()
+        {
+            Problem p = new Problem();
+            p.Type = "Parameter error";
+            p.Status = 400;
+            p.Title = "Illegal placment";
+            return p;
+        }
+
         public static Problem TooManyCellsSelected()
         {
             Problem p = new Problem();

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -68,6 +68,7 @@ namespace PxWeb
             builder.Services.AddSingleton<IPxCache, PxCache>();
             builder.Services.AddSingleton<ILinkCreator, LinkCreator>();
             builder.Services.AddSingleton<ISelectionHandler, SelectionHandler>();
+            builder.Services.AddSingleton<IPlacementHandler, PlacementHandler>();
             builder.Services.AddSingleton<IControllerStateProvider, ControllerStateProvider>();
 
             builder.Services.AddPxDataSource(builder);


### PR DESCRIPTION
- Modified `TableApiController.cs` to:
  * Inject `IPlacementHandler` dependency.
  * Use `CommaSeparatedStringToListOfStrings` model binder for `heading` and `stub` query parameters.
  * Replace inline placement logic with `PlacementHandler`.
- Added `VariablePlacementTests` class in `VariablePlacementTests.cs` to test `PlacementHandler`.
- Introduced `PlacementHandler` class in `PlacementHandler.cs` implementing `IPlacementHandler`.
- Added `IPlacementHandler` interface in `IPlacementHandler.cs`.
- Updated `ModelStore.cs` with `CreateModelA` method for sample `PXModel`.
- Added `CommaSeparatedStringToListOfStrings` model binder in `CommaSeparatedStringToListOfStrings.cs`.
- Added `IllegalPlacementSelection` method in `ProblemUtility.cs`.
- Registered `IPlacementHandler` service in `Program.cs`.