### PR TITLE
Fixed name of grouping and valuesets

### DIFF
--- a/PxWeb/Mappers/SelectionResponseMapper.cs
+++ b/PxWeb/Mappers/SelectionResponseMapper.cs
@@ -50,12 +50,12 @@ namespace PxWeb.Mappers
 
             if (variable.CurrentGrouping != null)
             {
-                return variable.CurrentGrouping.ID;
+                return "agg_" + variable.CurrentGrouping.ID;
             }
 
             if (variable.CurrentValueSet != null)
             {
-                return variable.CurrentValueSet.ID;
+                return "vs_" + variable.CurrentValueSet.ID;
             }
 
             return null;


### PR DESCRIPTION
Added agg_ and vs_ prefixes to the classification identifyer in the result for the default selection too match the metadata.