### PR TITLE
Fixed time placement and default number of columns

### DIFF
--- a/PxWeb.UnitTests/Data/DefaultSelectionTest.cs
+++ b/PxWeb.UnitTests/Data/DefaultSelectionTest.cs
@@ -80,7 +80,7 @@
             var o3 = selection.FirstOrDefault(x => x.VariableCode == meta.Variables[3].Code);
 
             Assert.IsNotNull(m1);
-            Assert.AreEqual(m1.ValueCodes.Count, 30);
+            Assert.AreEqual(m1.ValueCodes.Count, 11);
             Assert.IsNotNull(o1);
             Assert.AreEqual(o1.ValueCodes.Count, 0);
             Assert.IsNotNull(o2);
@@ -296,7 +296,7 @@
             Assert.IsNotNull(time);
             Assert.AreEqual(time.ValueCodes.Count, 1);
             Assert.IsNotNull(cls1);
-            Assert.AreEqual(cls1.ValueCodes.Count, 20);
+            Assert.AreEqual(cls1.ValueCodes.Count, 11);
             Assert.IsNotNull(cls2);
             Assert.AreEqual(cls2.ValueCodes.Count, 0);
             Assert.IsNotNull(cls3);
@@ -336,7 +336,7 @@
             Assert.IsNotNull(cls2);
             Assert.AreEqual(cls2.ValueCodes.Count, 20);
             Assert.IsNotNull(cls3m);
-            Assert.AreEqual(cls3m.ValueCodes.Count, 20);
+            Assert.AreEqual(cls3m.ValueCodes.Count, 11);
         }
 
         [TestMethod]
@@ -370,7 +370,7 @@
             Assert.IsNotNull(cls1);
             Assert.AreEqual(cls1.ValueCodes.Count, 0);
             Assert.IsNotNull(cls2m);
-            Assert.AreEqual(cls2m.ValueCodes.Count, 20);
+            Assert.AreEqual(cls2m.ValueCodes.Count, 11);
             Assert.IsNotNull(cls3m);
             Assert.AreEqual(cls3m.ValueCodes.Count, 20);
         }
@@ -407,7 +407,7 @@
             Assert.IsNotNull(cls1);
             Assert.AreEqual(cls1.ValueCodes.Count, 0);
             Assert.IsNotNull(cls2m);
-            Assert.AreEqual(cls2m.ValueCodes.Count, 20);
+            Assert.AreEqual(cls2m.ValueCodes.Count, 11);
             Assert.IsNotNull(cls3m);
             Assert.AreEqual(cls3m.ValueCodes.Count, 1);
             Assert.IsNotNull(cls4m);

--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -1556,7 +1556,7 @@ namespace PxWeb.Code.Api2.DataSelection
             selections.Add(selection);
         }
 
-        public static void AddHeadingVariable(this List<Selection> selections, Variable variable, Func<Variable, int, string[]> valuesFunction, int numberOfValues = 30)
+        public static void AddHeadingVariable(this List<Selection> selections, Variable variable, Func<Variable, int, string[]> valuesFunction, int numberOfValues = 11)
         {
             var selection = new Selection(variable.Code);
             selection.ValueCodes.AddRange(valuesFunction(variable, numberOfValues));

--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -1347,6 +1347,7 @@ namespace PxWeb.Code.Api2.DataSelection
             selections.AddVariableToHeading(contents, GetCodes);
             selections.AddVariableToHeading(time, GetTimeCodes);
             placmentHeading.Add(contents.Code);
+            placmentHeading.Add(time.Code);
 
             for (int i = 1; i < (mandatoryClassificationVariables.Count - 1); i++)
             {
@@ -1368,8 +1369,6 @@ namespace PxWeb.Code.Api2.DataSelection
                 selections.EliminateVariable(variable);
             }
 
-            //place time as last variable in heading
-            placmentHeading.Add(time.Code);
             return (selections, placmentHeading, placmentStub);
         }
 
@@ -1392,6 +1391,7 @@ namespace PxWeb.Code.Api2.DataSelection
             selections.AddVariableToHeading(contents, GetCodes);
             selections.AddVariableToHeading(time, GetTimeCodes);
             placmentHeading.Add(contents.Code);
+            placmentHeading.Add(time.Code);
 
             var lastNoneMandantoryClassificationVariable = noneMandatoryClassificationVariables.Last();
             var (stub, heading) = StubOrHeading(mandatoryClassificationVariables[0], lastNoneMandantoryClassificationVariable);
@@ -1408,8 +1408,7 @@ namespace PxWeb.Code.Api2.DataSelection
                     selections.EliminateVariable(variable);
                 }
             }
-            //place time as last variable in heading
-            placmentHeading.Add(time.Code);
+
             return (selections, placmentHeading, placmentStub);
         }
 
@@ -1432,6 +1431,7 @@ namespace PxWeb.Code.Api2.DataSelection
             selections.AddVariableToHeading(contents, GetCodes);
             selections.AddVariableToHeading(time, GetTimeCodes);
             placmentHeading.Add(contents.Code);
+            placmentHeading.Add(time.Code);
 
             var firstNoneMandantoryClassificationVariable = classificationVariables.First();
             var lastNoneMandantoryClassificationVariable = classificationVariables.Last();
@@ -1449,8 +1449,7 @@ namespace PxWeb.Code.Api2.DataSelection
                     selections.EliminateVariable(variable);
                 }
             }
-            //place time as last variable in heading
-            placmentHeading.Add(time.Code);
+
             return (selections, placmentHeading, placmentStub);
         }
 


### PR DESCRIPTION
Time is placed right after contents and before any other classification variable.

See PxWeb project Jira ticket PXWEB2-376