### PR TITLE
Fix for filing msbuild action 

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
+          DOTNET_ROOT: ${{ runner.temp }}/.dotnet
         with:
           global-json-file: "./global.json"
 


### PR DESCRIPTION
The msbuild action is failing on windows see same issue https://github.com/dotnet/sdk/issues/44957
This could be a potential quick fix