### PR TITLE
Fixes so that the values are the aggregated values only

### DIFF
--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -1151,6 +1151,10 @@ namespace PxWeb.Code.Api2.DataSelection
                 {
                     builder.ApplyValueSet(variable.Code, variable.ValueSets[0]);
                 }
+                else if (variable.CurrentGrouping != null)
+                {
+                    builder.ApplyGrouping(variable.Code, variable.GetGroupingInfoById(variable.CurrentGrouping.ID), GroupingIncludesType.AggregatedValues);
+                }
             }
 
             var contents = meta.Variables.FirstOrDefault(v => v.IsContentVariable);


### PR DESCRIPTION
Instead of getting all the values when a default grouping is applied we should only get the grouped values