### PR TITLE
Update the value when default ValueSet is used in DefaultSelection

### DIFF
--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -1155,6 +1155,10 @@ namespace PxWeb.Code.Api2.DataSelection
                 {
                     builder.ApplyGrouping(variable.Code, variable.GetGroupingInfoById(variable.CurrentGrouping.ID), GroupingIncludesType.AggregatedValues);
                 }
+                else if (variable.CurrentValueSet != null)
+                {
+                    builder.ApplyValueSet(variable.Code, variable.CurrentValueSet);
+                }
             }
 
             var contents = meta.Variables.FirstOrDefault(v => v.IsContentVariable);


### PR DESCRIPTION
Reapply the current ValueSet to make sure that the list of value are updated.

Fixes Jira issue PXWEB2-470 which is similar fix as #269 but that one is for groupings 
