### PR TITLE
Update PxWeb.csproj with revert of Microsoft.OpenApi.Readers

### DIFF
--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.4.1" />


### PR DESCRIPTION
Hmm, when  Microsoft.OpenApi.Readers is ="1.6.22"  , the generated swagger doc is  
{
  "openapi": "3.0.1",
  "info": {
   "title": "PxWebApi",
...
for 1.6.23 I get the same "Unable to render .." as this 

https://github.com/microsoft/OpenAPI.NET/issues/2030