### PR TITLE
Swagger page would not render

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
         applies-to: version-updates
         update-types:
           - "minor"
-
+    ignore:
+      - dependency-name: "Microsoft.OpenApi.Readers"
+        versions: ["1.6.23"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.4.1" />

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.4.1" />


### PR DESCRIPTION
There is a bug in [Microsoft.OpenApi.Readers](https://github.com/Microsoft/OpenAPI.NET) that leads to that the swagger UI cant render. @JohannesFinsveen had a fix on that #297  but dependabot reverted this with #298 that gets merged automatically since it is aminor version and all test passes. 
This PR reverte the dependabot changes and adds an ignore to the specific package. 