### PR TITLE
Removed outputvalues from the API

### DIFF
--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -260,7 +260,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="variablesSelection">VariablesSelection with the wanted variables and values</param>
         /// <param name="problem">Will be null if everything is ok, oterwise it will describe the problem</param>
         /// <returns></returns>
-        private bool VerifyVariableValues(PXModel model, VariablesSelection variablesSelection, out Problem? problem)
+        private static bool VerifyVariableValues(PXModel model, VariablesSelection variablesSelection, out Problem? problem)
         {
             problem = null;
 

--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -157,7 +157,7 @@ namespace PxWeb.Code.Api2.DataSelection
             return true;
         }
 
-        private bool ApplyCodelist(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
+        private static bool ApplyCodelist(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
         {
             problem = null;
 
@@ -187,7 +187,7 @@ namespace PxWeb.Code.Api2.DataSelection
             return true;
         }
 
-        private bool ApplyGrouping(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
+        private static bool ApplyGrouping(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
         {
             problem = null;
 
@@ -221,7 +221,7 @@ namespace PxWeb.Code.Api2.DataSelection
             return true;
         }
 
-        private bool ApplyValueset(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
+        private static bool ApplyValueset(IPXModelBuilder builder, Variable pxVariable, VariableSelection variable, out Problem? problem)
         {
             problem = null;
 
@@ -323,7 +323,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The selection expression to verify</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifySelectionExpression(string expression)
+        private static bool VerifySelectionExpression(string expression)
         {
             if (expression.Contains('*'))
             {
@@ -362,7 +362,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The wildcard selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyWildcardStarExpression(string expression)
+        private static bool VerifyWildcardStarExpression(string expression)
         {
             if (expression.Equals("*"))
             {
@@ -397,7 +397,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The wildcard selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyWildcardQuestionmarkExpression(string expression)
+        private static bool VerifyWildcardQuestionmarkExpression(string expression)
         {
             // What could be wrong?
             return true;
@@ -408,7 +408,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The TOP selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyTopExpression(string expression)
+        private static bool VerifyTopExpression(string expression)
         {
             return Regex.IsMatch(expression, REGEX_TOP, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
@@ -418,7 +418,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The BOTTOM selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyBottomExpression(string expression)
+        private static bool VerifyBottomExpression(string expression)
         {
             return Regex.IsMatch(expression, REGEX_BOTTOM, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
@@ -428,7 +428,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The RANGE selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyRangeExpression(string expression)
+        private static bool VerifyRangeExpression(string expression)
         {
             return Regex.IsMatch(expression, REGEX_RANGE, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
@@ -438,7 +438,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The FROM selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyFromExpression(string expression)
+        private static bool VerifyFromExpression(string expression)
         {
             return Regex.IsMatch(expression, REGEX_FROM, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
@@ -448,7 +448,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="expression">The TO selection expression to validate</param>
         /// <returns>True if the expression is valid, else false</returns>
-        private bool VerifyToExpression(string expression)
+        private static bool VerifyToExpression(string expression)
         {
             return Regex.IsMatch(expression, REGEX_TO, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
@@ -458,7 +458,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        private bool IsSelectionExpression(string value)
+        private static bool IsSelectionExpression(string value)
         {
             return value.Contains('*') ||
                    value.Contains('?') ||
@@ -475,7 +475,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="variablesSelection"></param>
         /// <param name="model"></param>
         /// <returns></returns>
-        private VariablesSelection AddVariables(VariablesSelection variablesSelection, PXModel model)
+        private static VariablesSelection AddVariables(VariablesSelection variablesSelection, PXModel model)
         {
             foreach (var variable in model.Meta.Variables)
             {
@@ -500,7 +500,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="variablesSelection"></param>
         /// <returns></returns>
-        private Selection[] MapCustomizedSelection(PXModel model, VariablesSelection variablesSelection)
+        private static Selection[] MapCustomizedSelection(PXModel model, VariablesSelection variablesSelection)
         {
             var selections = new List<Selection>();
 
@@ -519,7 +519,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="variable">Paxiom variable</param>
         /// <param name="varSelection">VariableSelection object with wanted values from user</param>
         /// <returns></returns>
-        private Selection GetSelection(Variable variable, VariableSelection varSelection)
+        private static Selection GetSelection(Variable variable, VariableSelection varSelection)
         {
             var selection = new Selection(varSelection.VariableCode);
             var values = new List<string>();
@@ -582,7 +582,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="variable">The Paxiom variable</param>
         /// <param name="values">Unsorted list of selected values</param>
         /// <returns>Sorted list of selected values</returns>
-        private List<string> SortValues(Variable variable, List<string> values)
+        private static List<string> SortValues(Variable variable, List<string> values)
         {
             var sortedValues = new List<string>();
 
@@ -603,7 +603,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="wildcard">The wildcard string</param>
-        private void AddWildcardStarValues(Variable variable, List<string> values, string wildcard)
+        private static void AddWildcardStarValues(Variable variable, List<string> values, string wildcard)
         {
             if (wildcard.Equals("*"))
             {
@@ -647,7 +647,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="wildcard">The wildcard string</param>
-        private void AddWildcardQuestionmarkValues(Variable variable, List<string> values, string wildcard)
+        private static void AddWildcardQuestionmarkValues(Variable variable, List<string> values, string wildcard)
         {
             string regexPattern = string.Concat("^", Regex.Escape(wildcard).Replace("\\?", "."), "$");
             var variableValues = variable.Values.Where(v => Regex.IsMatch(v.Code, regexPattern, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100))).Select(v => v.Code);
@@ -664,7 +664,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="expression">The TOP selection expression string</param>
-        private void AddTopValues(Variable variable, List<string> values, string expression)
+        private static void AddTopValues(Variable variable, List<string> values, string expression)
         {
             int count;
             int offset;
@@ -697,7 +697,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="expression">The BOTTOM selection expression string</param>
-        private void AddBottomValues(Variable variable, List<string> values, string expression)
+        private static void AddBottomValues(Variable variable, List<string> values, string expression)
         {
             int count;
             int offset;
@@ -736,7 +736,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="expression">The RANGE selection expression string</param>
-        private void AddRangeValues(Variable variable, List<string> values, string expression)
+        private static void AddRangeValues(Variable variable, List<string> values, string expression)
         {
             string code1 = "";
             string code2 = "";
@@ -781,7 +781,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="expression">The FROM selection expression string</param>
-        private void AddFromValues(Variable variable, List<string> values, string expression)
+        private static void AddFromValues(Variable variable, List<string> values, string expression)
         {
             string code = "";
 
@@ -815,7 +815,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="aggregatedSingle">Indicates if single values from aggregation groups shall be added</param>
         /// <param name="values">List that the values shall be added to</param>
         /// <param name="expression">The TO selection expression string</param>
-        private void AddToValues(Variable variable, List<string> values, string expression)
+        private static void AddToValues(Variable variable, List<string> values, string expression)
         {
             string code = "";
 
@@ -849,7 +849,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="count">Set to the count value if it could be extracted, else 0</param>
         /// <param name="offset">Set to the offset value if it could be extracted, else 0</param>
         /// <returns>True if values could be extracted, false if something went wrong</returns>
-        private bool GetCountAndOffset(string expression, out int count, out int offset)
+        private static bool GetCountAndOffset(string expression, out int count, out int offset)
         {
             count = 0;
             offset = 0;
@@ -894,7 +894,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="code1">The firts code</param>
         /// <param name="code2">The second code</param>
         /// <returns>True if the codes could be extracted, false if something went wrong</returns>
-        private bool GetRangeCodes(string expression, out string code1, out string code2)
+        private static bool GetRangeCodes(string expression, out string code1, out string code2)
         {
             code1 = "";
             code2 = "";
@@ -934,7 +934,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="codes">Array of codes</param>
         /// <param name="code">Code to find index for</param>
         /// <returns>Index of the specified code within the codes array. If not found -1 is returned.</returns>
-        private int GetCodeIndex(string[] codes, string code)
+        private static int GetCodeIndex(string[] codes, string code)
         {
             // Try to get the value using the code specified by the API user
             int index = Array.IndexOf(codes, code);
@@ -960,7 +960,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="expression">The Range selection expression to extract the code from</param>
         /// <param name="code">The code</param>
         /// <returns>True if teh code could be extracted, false if something went wrong</returns>
-        private bool GetSingleCode(string expression, out string code)
+        private static bool GetSingleCode(string expression, out string code)
         {
             code = "";
 
@@ -984,13 +984,13 @@ namespace PxWeb.Code.Api2.DataSelection
         }
 
 
-        private List<Variable> GetAllMandatoryVariables(PXModel model)
+        private static List<Variable> GetAllMandatoryVariables(PXModel model)
         {
             var mandatoryVariables = model.Meta.Variables.Where(x => x.Elimination.Equals(false)).ToList();
             return mandatoryVariables;
         }
 
-        private bool Mandatory(PXModel model, VariableSelection variable)
+        private static bool Mandatory(PXModel model, VariableSelection variable)
         {
             bool mandatory = false;
             var mandatoryVariable = model.Meta.Variables.Where(x => x.Code.Equals(variable.VariableCode) && x.Elimination.Equals(false));
@@ -1020,7 +1020,7 @@ namespace PxWeb.Code.Api2.DataSelection
             return codes;
         }
 
-        private bool HasSelection(VariablesSelection selection)
+        private static bool HasSelection(VariablesSelection selection)
         {
             if (selection.Selection.Count == 0)
             {
@@ -1038,7 +1038,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="builder">Paxiom model builder</param>
         /// <param name="selections">Selections made by the SelectionHandler</param>
         /// <returns>True if all mandatory variables have at least one selected value, else false</returns>
-        private bool VerifyMadeSelection(IPXModelBuilder builder, Selection[]? selections)
+        private static bool VerifyMadeSelection(IPXModelBuilder builder, Selection[]? selections)
         {
             if (selections is null)
             {
@@ -1071,7 +1071,7 @@ namespace PxWeb.Code.Api2.DataSelection
         }
 
 
-        private int CalculateCells(Selection[] selection)
+        private static int CalculateCells(Selection[] selection)
         {
             int cells = 1;
 

--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -58,7 +58,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 variablesSelection = AddVariables(variablesSelection, builder.Model);
 
                 //Map VariablesSelection to PCaxis.Paxiom.Selection[]
-                selections = MapCustomizedSelection(builder, builder.Model, variablesSelection).ToArray();
+                selections = MapCustomizedSelection(builder.Model, variablesSelection).ToArray();
             }
             else
             {
@@ -500,14 +500,14 @@ namespace PxWeb.Code.Api2.DataSelection
         /// </summary>
         /// <param name="variablesSelection"></param>
         /// <returns></returns>
-        private Selection[] MapCustomizedSelection(IPXModelBuilder builder, PXModel model, VariablesSelection variablesSelection)
+        private Selection[] MapCustomizedSelection(PXModel model, VariablesSelection variablesSelection)
         {
             var selections = new List<Selection>();
 
             foreach (var varSelection in variablesSelection.Selection)
             {
                 var variable = model.Meta.Variables.GetByCode(varSelection.VariableCode);
-                selections.Add(GetSelection(builder, variable, varSelection));
+                selections.Add(GetSelection(variable, varSelection));
             }
 
             return selections.ToArray();
@@ -519,7 +519,7 @@ namespace PxWeb.Code.Api2.DataSelection
         /// <param name="variable">Paxiom variable</param>
         /// <param name="varSelection">VariableSelection object with wanted values from user</param>
         /// <returns></returns>
-        private Selection GetSelection(IPXModelBuilder builder, Variable variable, VariableSelection varSelection)
+        private Selection GetSelection(Variable variable, VariableSelection varSelection)
         {
             var selection = new Selection(varSelection.VariableCode);
             var values = new List<string>();
@@ -556,7 +556,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 }
                 else
                 {
-                    AddValue(variable, values, value);
+                    AddValue(values, value);
                 }
             }
 
@@ -567,7 +567,7 @@ namespace PxWeb.Code.Api2.DataSelection
             return selection;
         }
 
-        private void AddValue(Variable variable, List<string> values, string value)
+        private static void AddValue(List<string> values, string value)
         {
             if (!values.Contains(value))
             {
@@ -611,7 +611,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 var variableValues = variable.Values.Select(v => v.Code);
                 foreach (var variableValue in variableValues)
                 {
-                    AddValue(variable, values, variableValue);
+                    AddValue(values, variableValue);
                 }
             }
             else if (wildcard.StartsWith("*") && wildcard.EndsWith("*"))
@@ -619,7 +619,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 var variableValues = variable.Values.Where(v => v.Code.Contains(wildcard.Substring(1, wildcard.Length - 2), StringComparison.InvariantCultureIgnoreCase)).Select(v => v.Code);
                 foreach (var variableValue in variableValues)
                 {
-                    AddValue(variable, values, variableValue);
+                    AddValue(values, variableValue);
                 }
             }
             else if (wildcard.StartsWith("*"))
@@ -627,7 +627,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 var variableValues = variable.Values.Where(v => v.Code.EndsWith(wildcard.Substring(1), StringComparison.InvariantCultureIgnoreCase)).Select(v => v.Code);
                 foreach (var variableValue in variableValues)
                 {
-                    AddValue(variable, values, variableValue);
+                    AddValue(values, variableValue);
                 }
             }
             else if (wildcard.EndsWith("*"))
@@ -635,7 +635,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 var variableValues = variable.Values.Where(v => v.Code.StartsWith(wildcard.Substring(0, wildcard.Length - 1), StringComparison.InvariantCultureIgnoreCase)).Select(v => v.Code);
                 foreach (var variableValue in variableValues)
                 {
-                    AddValue(variable, values, variableValue);
+                    AddValue(values, variableValue);
                 }
             }
         }
@@ -653,7 +653,7 @@ namespace PxWeb.Code.Api2.DataSelection
             var variableValues = variable.Values.Where(v => Regex.IsMatch(v.Code, regexPattern, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100))).Select(v => v.Code);
             foreach (var variableValue in variableValues)
             {
-                AddValue(variable, values, variableValue);
+                AddValue(values, variableValue);
             }
         }
 
@@ -685,7 +685,7 @@ namespace PxWeb.Code.Api2.DataSelection
             {
                 if (i < codes.Length)
                 {
-                    AddValue(variable, values, codes[i]);
+                    AddValue(values, codes[i]);
                 }
             }
         }
@@ -723,7 +723,7 @@ namespace PxWeb.Code.Api2.DataSelection
                 {
                     if (i >= 0)
                     {
-                        AddValue(variable, values, codes[i]);
+                        AddValue(values, codes[i]);
                     }
                 }
             }
@@ -769,7 +769,7 @@ namespace PxWeb.Code.Api2.DataSelection
             {
                 for (int i = index1; i <= index2; i++)
                 {
-                    AddValue(variable, values, codes[i]);
+                    AddValue(values, codes[i]);
                 }
             }
         }
@@ -803,7 +803,7 @@ namespace PxWeb.Code.Api2.DataSelection
             {
                 for (int i = index1; i < codes.Length; i++)
                 {
-                    AddValue(variable, values, codes[i]);
+                    AddValue(values, codes[i]);
                 }
             }
         }
@@ -837,7 +837,7 @@ namespace PxWeb.Code.Api2.DataSelection
             {
                 for (int i = 0; i <= index; i++)
                 {
-                    AddValue(variable, values, codes[i]);
+                    AddValue(values, codes[i]);
                 }
             }
         }

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -178,14 +178,13 @@ namespace PxWeb.Controllers.Api2
             [FromRoute(Name = "id"), Required] string id,
             [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "valuecodes"), ModelBinder(typeof(QueryStringToDictionaryOfStrings))] Dictionary<string, List<string>>? valuecodes,
             [FromQuery(Name = "codelist")] Dictionary<string, string>? codelist,
-            [FromQuery(Name = "outputvalues")] Dictionary<string, CodeListOutputValuesType>? outputvalues,
             [FromQuery(Name = "outputFormat")] OutputFormatType? outputFormat,
             //[FromQuery(Name = "outputFormatParams"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<OutputFormatParamType>? outputFormatParams,
             [FromQuery(Name = "outputFormatParams"), ModelBinder(typeof(OutputFormatParamsModelBinder))] List<OutputFormatParamType>? outputFormatParams,
             [FromQuery(Name = "heading"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? heading,
             [FromQuery(Name = "stub"), ModelBinder(typeof(CommaSeparatedStringToListOfStrings))] List<string>? stub)
         {
-            VariablesSelection variablesSelection = MapDataParameters(valuecodes, codelist, outputvalues, heading, stub);
+            VariablesSelection variablesSelection = MapDataParameters(valuecodes, codelist, heading, stub);
             return GetData(id, lang, variablesSelection, outputFormat, outputFormatParams is null ? new List<OutputFormatParamType>() : outputFormatParams);
         }
 
@@ -341,7 +340,7 @@ namespace PxWeb.Controllers.Api2
         /// <param name="heading"></param>
         /// <param name="stub"></param> 
         /// <returns></returns>
-        private VariablesSelection MapDataParameters(Dictionary<string, List<string>>? valuecodes, Dictionary<string, string>? codelist, Dictionary<string, CodeListOutputValuesType>? outputvalues, List<string>? heading, List<string>? stub)
+        private VariablesSelection MapDataParameters(Dictionary<string, List<string>>? valuecodes, Dictionary<string, string>? codelist, List<string>? heading, List<string>? stub)
         {
             VariablesSelection selections = new VariablesSelection();
             if (valuecodes != null)
@@ -355,10 +354,6 @@ namespace PxWeb.Controllers.Api2
                     if (codelist != null && codelist.ContainsKey(variableCode))
                     {
                         variableSelection.CodeList = codelist[variableCode];
-                    }
-                    if (outputvalues != null && outputvalues.ContainsKey(variableCode))
-                    {
-                        variableSelection.OutputValues = outputvalues[variableCode];
                     }
                     selections.Selection.Add(variableSelection);
                 }

--- a/PxWeb/Mappers/SelectionResponseMapper.cs
+++ b/PxWeb/Mappers/SelectionResponseMapper.cs
@@ -23,7 +23,6 @@ namespace PxWeb.Mappers
             {
                 VariableCode = selection.VariableCode,
                 CodeList = GetCodeList(meta.Variables.FirstOrDefault(v => string.Compare(v.Code, selection.VariableCode, true) == 0)),
-                OutputValues = CodeListOutputValuesType.AggregatedEnum,
                 ValueCodes = selection.ValueCodes.Cast<string>().ToList(),
             }).ToList();
 

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.4.1" />
     <PackageReference Include="PcAxis.Sql" Version="1.2.8" />
-    <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.8" />
+    <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />

--- a/PxWeb/wwwroot/Database/Menu.xml
+++ b/PxWeb/wwwroot/Database/Menu.xml
@@ -31,9 +31,9 @@
             <Attribute name="Var4NumberOfValues">28</Attribute>
             <Attribute name="size">27584</Attribute>
             <Attribute name="cells">4312</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1990</StartTime>
             <EndTime>2017</EndTime>
@@ -56,9 +56,9 @@
             <Attribute name="Var4NumberOfValues">2</Attribute>
             <Attribute name="size">49482</Attribute>
             <Attribute name="cells">6402</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230831 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-08-31 15:42:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2015</EndTime>
@@ -86,9 +86,9 @@
             <Attribute name="Var4NumberOfValues">4</Attribute>
             <Attribute name="size">15488</Attribute>
             <Attribute name="cells">2448</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 16:13</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 16:13:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2016</EndTime>
@@ -124,9 +124,9 @@
             <Attribute name="Var5NumberOfValues">3</Attribute>
             <Attribute name="size">44877</Attribute>
             <Attribute name="cells">5940</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1981</StartTime>
             <EndTime>2001</EndTime>
@@ -155,9 +155,9 @@
             <Attribute name="Var6NumberOfValues">2</Attribute>
             <Attribute name="size">122406</Attribute>
             <Attribute name="cells">19800</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1991</StartTime>
             <EndTime>2001</EndTime>
@@ -200,9 +200,9 @@
             <Attribute name="Var5NumberOfValues">3</Attribute>
             <Attribute name="size">44877</Attribute>
             <Attribute name="cells">5940</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1981</StartTime>
             <EndTime>2001</EndTime>
@@ -231,9 +231,9 @@
             <Attribute name="Var6NumberOfValues">2</Attribute>
             <Attribute name="size">122406</Attribute>
             <Attribute name="cells">19800</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1991</StartTime>
             <EndTime>2001</EndTime>
@@ -266,9 +266,9 @@
             <Attribute name="Var4NumberOfValues">4</Attribute>
             <Attribute name="size">15488</Attribute>
             <Attribute name="cells">2448</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 16:13</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 16:13:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2016</EndTime>
@@ -296,9 +296,9 @@
             <Attribute name="Var4NumberOfValues">28</Attribute>
             <Attribute name="size">27584</Attribute>
             <Attribute name="cells">4312</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1990</StartTime>
             <EndTime>2017</EndTime>
@@ -321,9 +321,9 @@
             <Attribute name="Var4NumberOfValues">2</Attribute>
             <Attribute name="size">49482</Attribute>
             <Attribute name="cells">6402</Attribute>
-            <Attribute name="updated">20231101 17:42</Attribute>
+            <Attribute name="updated">20240826 12:42</Attribute>
             <Attribute name="modified">20230831 15:42</Attribute>
-            <Published>2023-11-01 17:42:03</Published>
+            <Published>2024-08-26 12:42:08</Published>
             <LastUpdated>2023-08-31 15:42:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2015</EndTime>

--- a/PxWeb/wwwroot/Database/Menu.xml
+++ b/PxWeb/wwwroot/Database/Menu.xml
@@ -31,9 +31,9 @@
             <Attribute name="Var4NumberOfValues">28</Attribute>
             <Attribute name="size">27584</Attribute>
             <Attribute name="cells">4312</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1990</StartTime>
             <EndTime>2017</EndTime>
@@ -56,9 +56,9 @@
             <Attribute name="Var4NumberOfValues">2</Attribute>
             <Attribute name="size">49482</Attribute>
             <Attribute name="cells">6402</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230831 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-08-31 15:42:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2015</EndTime>
@@ -86,9 +86,9 @@
             <Attribute name="Var4NumberOfValues">4</Attribute>
             <Attribute name="size">15488</Attribute>
             <Attribute name="cells">2448</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 16:13</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 16:13:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2016</EndTime>
@@ -124,9 +124,9 @@
             <Attribute name="Var5NumberOfValues">3</Attribute>
             <Attribute name="size">44877</Attribute>
             <Attribute name="cells">5940</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1981</StartTime>
             <EndTime>2001</EndTime>
@@ -155,9 +155,9 @@
             <Attribute name="Var6NumberOfValues">2</Attribute>
             <Attribute name="size">122406</Attribute>
             <Attribute name="cells">19800</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1991</StartTime>
             <EndTime>2001</EndTime>
@@ -200,9 +200,9 @@
             <Attribute name="Var5NumberOfValues">3</Attribute>
             <Attribute name="size">44877</Attribute>
             <Attribute name="cells">5940</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1981</StartTime>
             <EndTime>2001</EndTime>
@@ -231,9 +231,9 @@
             <Attribute name="Var6NumberOfValues">2</Attribute>
             <Attribute name="size">122406</Attribute>
             <Attribute name="cells">19800</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1991</StartTime>
             <EndTime>2001</EndTime>
@@ -266,9 +266,9 @@
             <Attribute name="Var4NumberOfValues">4</Attribute>
             <Attribute name="size">15488</Attribute>
             <Attribute name="cells">2448</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 16:13</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 16:13:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2016</EndTime>
@@ -296,9 +296,9 @@
             <Attribute name="Var4NumberOfValues">28</Attribute>
             <Attribute name="size">27584</Attribute>
             <Attribute name="cells">4312</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230525 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-05-25 15:42:00</LastUpdated>
             <StartTime>1990</StartTime>
             <EndTime>2017</EndTime>
@@ -321,9 +321,9 @@
             <Attribute name="Var4NumberOfValues">2</Attribute>
             <Attribute name="size">49482</Attribute>
             <Attribute name="cells">6402</Attribute>
-            <Attribute name="updated">20240826 12:42</Attribute>
+            <Attribute name="updated">20231101 17:42</Attribute>
             <Attribute name="modified">20230831 15:42</Attribute>
-            <Published>2024-08-26 12:42:08</Published>
+            <Published>2023-11-01 17:42:03</Published>
             <LastUpdated>2023-08-31 15:42:00</LastUpdated>
             <StartTime>2010</StartTime>
             <EndTime>2015</EndTime>

--- a/PxWebApi_Mvc.Tests/ExpectedJson/MetadataById_tab004_js2.json
+++ b/PxWebApi_Mvc.Tests/ExpectedJson/MetadataById_tab004_js2.json
@@ -79,8 +79,7 @@
       "extension": {
         "elimination": false,
         "show": "value",
-        "codeLists": [],
-        "timeUnit": 0
+        "codeLists": []
       }
     },
     "GREENHOUSEGAS": {
@@ -121,8 +120,7 @@
       "extension": {
         "elimination": false,
         "show": "value",
-        "codeLists": [],
-        "timeUnit": 0
+        "codeLists": []
       }
     },
     "ContentsCode": {
@@ -144,8 +142,7 @@
       "extension": {
         "elimination": false,
         "show": "value",
-        "codeLists": [],
-        "timeUnit": 0
+        "codeLists": []
       }
     },
     "TIME": {
@@ -215,8 +212,7 @@
       "extension": {
         "elimination": false,
         "show": "code",
-        "codeLists": [],
-        "timeUnit": 0
+        "codeLists": []
       }
     }
   },


### PR DESCRIPTION
Simplified `SelectionHandler.cs` by removing `aggregatedSingle` parameter and related logic.

Removed `outputvalues` parameter from `GetTableData` in `TableApiController.cs` and updated `MapDataParameters` accordingly.

Removed `OutputValues` property from `SelectionResponseMapper.cs`.

Updated `PxWeb.Api2.Server` package to `2.0.0-beta.10`.

