### PR TITLE
GetTableMetadataJsonLink now return just one link, as support for  "j…

### DIFF
--- a/PxWeb/Mappers/DatasetMapper.cs
+++ b/PxWeb/Mappers/DatasetMapper.cs
@@ -145,7 +145,7 @@ namespace PxWeb.Mappers
             AddTableNotes(model, dataset);
 
             List<Link> linksOnRoot = new List<Link>();
-            linksOnRoot.AddRange(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.self, id.ToUpper(), language, true));
+            linksOnRoot.Add(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.self, id.ToUpper(), language, true));
             linksOnRoot.Add(_linkCreator.GetTableDataLink(LinkCreator.LinkRelationEnum.data, id.ToUpper(), language, true));
 
             //"type": "application/json"

--- a/PxWeb/Mappers/FolderResponseMapper.cs
+++ b/PxWeb/Mappers/FolderResponseMapper.cs
@@ -117,7 +117,7 @@ namespace PxWeb.Mappers
             table.Links.Add(_linkCreator.GetTableLink(LinkCreator.LinkRelationEnum.self, tableId, _language, true));
 
             // Links to metadata
-            table.Links.AddRange(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, tableId, _language, true));
+            table.Links.Add(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, tableId, _language, true));
 
             // Links to data
             table.Links.Add(_linkCreator.GetTableDataLink(LinkCreator.LinkRelationEnum.data, tableId, _language, true));

--- a/PxWeb/Mappers/ILinkCreator.cs
+++ b/PxWeb/Mappers/ILinkCreator.cs
@@ -8,7 +8,7 @@ namespace PxWeb.Mappers
     {
         Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int pagesize, int pageNumber, bool showLangParam = true);
         Link GetTableLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
-        List<Link> GetTableMetadataJsonLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
+        Link GetTableMetadataJsonLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetTableDataLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetCodelistLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetFolderLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);

--- a/PxWeb/Mappers/LinkCreator.cs
+++ b/PxWeb/Mappers/LinkCreator.cs
@@ -22,8 +22,6 @@ namespace PxWeb.Mappers
 
         private readonly string _urlPrefix;
         private readonly string _defaultDataFormat;
-        private readonly List<string> _metaFormats = new List<string> { "json-px", "json-stat2" };
-        //Could not get the strings cleanly from MetadataOutputFormatType. Anybody?
 
         public LinkCreator(IOptions<PxApiConfigurationOptions> configOptions)
         {
@@ -50,21 +48,14 @@ namespace PxWeb.Mappers
             return link;
         }
 
-        public List<Link> GetTableMetadataJsonLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true)
+        public Link GetTableMetadataJsonLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true)
         {
-            List<Link> links = new List<Link>();
+            Link link = new Link();
+            link.Rel = relation.ToString();
+            link.Hreflang = language;
+            link.Href = CreateURL($"tables/{id}/metadata", language, showLangParam, null);
 
-            foreach (string outFormat in _metaFormats)
-            {
-                var link = new Link();
-                link.Rel = relation.ToString();
-                link.Hreflang = language;
-
-                link.Href = CreateURL($"tables/{id}/metadata", language, showLangParam, outFormat);
-                links.Add(link);
-            }
-
-            return links;
+            return link;
         }
 
         public Link GetTableDataLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true)

--- a/PxWeb/Mappers/TableResponseMapper.cs
+++ b/PxWeb/Mappers/TableResponseMapper.cs
@@ -28,7 +28,7 @@ namespace PxWeb.Mappers
             linkList.Add(_linkCreator.GetTableLink(LinkCreator.LinkRelationEnum.self, searchResult.Id.ToUpper(), lang, true));
 
             // Links to metadata
-            linkList.AddRange(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, searchResult.Id.ToUpper(), lang, true));
+            linkList.Add(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, searchResult.Id.ToUpper(), lang, true));
 
             // Links to data
             linkList.Add(_linkCreator.GetTableDataLink(LinkCreator.LinkRelationEnum.data, searchResult.Id.ToUpper(), lang, true));

--- a/PxWeb/Mappers/TablesResponseMapper.cs
+++ b/PxWeb/Mappers/TablesResponseMapper.cs
@@ -68,7 +68,7 @@ namespace PxWeb.Mappers
                 linkList.Add(_linkCreator.GetTableLink(LinkCreator.LinkRelationEnum.self, item.Id.ToUpper(), lang, true));
 
                 // Links to metadata
-                linkList.AddRange(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, item.Id.ToUpper(), lang, true));
+                linkList.Add(_linkCreator.GetTableMetadataJsonLink(LinkCreator.LinkRelationEnum.metadata, item.Id.ToUpper(), lang, true));
 
                 // Links to data
                 linkList.Add(_linkCreator.GetTableDataLink(LinkCreator.LinkRelationEnum.data, item.Id.ToUpper(), lang, true));


### PR DESCRIPTION
…son-px" has ended.
was:
{"rel":"metadata","hreflang":"no","href":"https://data.ssb.no/api/pxwebapi/v2-beta/tables/14282/metadata?lang=no&outputFormat=json-px"},
{"rel":"metadata","hreflang":"no","href":"https://data.ssb.no/api/pxwebapi/v2-beta/tables/14282/metadata?lang=no&outputFormat=json-stat2"},
now just one without the outputFormat  
