### PR TITLE
fix(tables): Source and TimeUnit is now maped in the tables response

### DIFF
--- a/Px.Search/SearchResult.cs
+++ b/Px.Search/SearchResult.cs
@@ -8,6 +8,8 @@
         public SearchResult(string id, string label, string category, string firstPeriod, string lastPeriod, string[] variableNames, string source, string timeUnit)
             : base(id, label, category, firstPeriod, lastPeriod, variableNames)
         {
+            Source = source;
+            TimeUnit = timeUnit;
         }
 
         public float Score { get; set; }

--- a/PxWebApi_Mvc.Tests/ExpectedJson/ListAllTables.json
+++ b/PxWebApi_Mvc.Tests/ExpectedJson/ListAllTables.json
@@ -16,8 +16,8 @@
                 "contents",
                 "year"
             ],
-            "source": "",
-            "timeUnit": "Other",
+            "source": "Statistics Sweden",
+            "timeUnit": "Annual",
             "paths": [
                 [
                     {
@@ -63,8 +63,8 @@
                 "contents",
                 "year"
             ],
-            "source": "",
-            "timeUnit": "Other",
+            "source": "Statistics Sweden",
+            "timeUnit": "Annual",
             "paths": [
                 [
                     {
@@ -110,8 +110,8 @@
                 "contents",
                 "year"
             ],
-            "source": "",
-            "timeUnit": "Other",
+            "source": "Statistics Sweden",
+            "timeUnit": "Annual",
             "paths": [
                 [
                     {
@@ -158,8 +158,8 @@
                 "contents",
                 "year"
             ],
-            "source": "",
-            "timeUnit": "Other",
+            "source": "Eurostat",
+            "timeUnit": "Annual",
             "paths": [
                 [
                     {
@@ -207,8 +207,8 @@
                 "contents",
                 "year"
             ],
-            "source": "",
-            "timeUnit": "Other",
+            "source": "Eurostat",
+            "timeUnit": "Annual",
             "paths": [
                 [
                     {

--- a/PxWebApi_Mvc.Tests/ExpectedJson/TableById_tab004.json
+++ b/PxWebApi_Mvc.Tests/ExpectedJson/TableById_tab004.json
@@ -14,8 +14,8 @@
         "contents",
         "year"
     ],
-    "source": "",
-    "timeUnit": "Other",
+    "source": "Statistics Sweden",
+    "timeUnit": "Annual",
     "paths": [
         [
             {


### PR DESCRIPTION
Source and TimeUnits where previously not map to the response instead default where returned in the response. This PR set the correct values from the search index.