### PR TITLE
feat(saved-query): Create saved query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -490,3 +490,4 @@ docker/pxwebapi/database/*
 !docker/pxwebapi/database/README.md
 !docker/pxwebapi/database/tinydatabase.zip
 SqlDb.config
+*.sqa

--- a/.gitignore
+++ b/.gitignore
@@ -491,3 +491,4 @@ docker/pxwebapi/database/*
 !docker/pxwebapi/database/tinydatabase.zip
 SqlDb.config
 *.sqa
+*.sqs

--- a/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
+++ b/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
@@ -2,7 +2,7 @@
 {
     public interface ISavedQueryStorageBackend
     {
-        string Save(string savedQuery);
+        string Save(string savedQuery, string tableId, string language);
         string Load(string id);
         bool UpdateRunStatistics(string id);
     }

--- a/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
+++ b/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
@@ -1,0 +1,9 @@
+﻿namespace Px.Abstractions.Interfaces
+{
+    public interface ISavedQueryStorageBackend
+    {
+        string Save(string savedQuery);
+        string Load(string id);
+        void UpdateRunStatistics(string id);
+    }
+}

--- a/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
+++ b/Px.Abstractions/Interfaces/ISavedQueryStorageBackend.cs
@@ -4,6 +4,6 @@
     {
         string Save(string savedQuery);
         string Load(string id);
-        void UpdateRunStatistics(string id);
+        bool UpdateRunStatistics(string id);
     }
 }

--- a/PxWeb.UnitTests/SavedQuery/SaveQueryFileStorgeBackendTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SaveQueryFileStorgeBackendTests.cs
@@ -15,7 +15,7 @@ namespace PxWeb.UnitTests.SavedQuery
             var options = new Mock<IOptions<SavedQueryFileStorageOptions>>();
             options.Setup(x => x.Value).Returns(settings);
             var host = new Mock<IPxHost>();
-            host.Setup(h => h.RootPath).Returns(Path.GetTempPath);
+            host.Setup(h => h.RootPath).Returns(Path.GetTempPath());
             var backend = new SaveQueryFileStorgeBackend(options.Object, host.Object);
 
             // Act
@@ -24,5 +24,29 @@ namespace PxWeb.UnitTests.SavedQuery
             // Assert
             Assert.IsFalse(result);
         }
+
+        [TestMethod]
+        public void UpdatedRunStatistics_WhenNoFileButQuery_ReturnTrueAndCreatesFile()
+        {
+            // Arrange
+            var settings = new SavedQueryFileStorageOptions() { Path = "SQ" };
+            var options = new Mock<IOptions<SavedQueryFileStorageOptions>>();
+            options.Setup(x => x.Value).Returns(settings);
+            var host = new Mock<IPxHost>();
+            host.Setup(h => h.RootPath).Returns(Path.GetTempPath());
+            var backend = new SaveQueryFileStorgeBackend(options.Object, host.Object);
+
+            var path = Path.Combine(Path.GetTempPath(), "SQ", "i");
+            Directory.CreateDirectory(path);
+            File.CreateText(Path.Combine(path, "id.sqa")).Close();
+
+            // Act
+            var result = backend.UpdateRunStatistics("id");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
     }
+
+
 }

--- a/PxWeb.UnitTests/SavedQuery/SaveQueryFileStorgeBackendTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SaveQueryFileStorgeBackendTests.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Options;
+
+using PxWeb.Code.Api2.SavedQueryBackend.FileBackend;
+
+namespace PxWeb.UnitTests.SavedQuery
+{
+    [TestClass]
+    public class SaveQueryFileStorgeBackendTests
+    {
+        [TestMethod]
+        public void UpdatedRunStatistics_WhenNoFileAndNoQuery_ReturnsFalse()
+        {
+            // Arrange
+            var settings = new SavedQueryFileStorageOptions() { Path = "SQ" };
+            var options = new Mock<IOptions<SavedQueryFileStorageOptions>>();
+            options.Setup(x => x.Value).Returns(settings);
+            var host = new Mock<IPxHost>();
+            host.Setup(h => h.RootPath).Returns(Path.GetTempPath);
+            var backend = new SaveQueryFileStorgeBackend(options.Object, host.Object);
+
+            // Act
+            var result = backend.UpdateRunStatistics("no-id");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageBackendTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageBackendTests.cs
@@ -37,7 +37,7 @@ namespace PxWeb.UnitTests.SavedQuery
 
 
             // Act & Assert
-            Assert.ThrowsExactly<ArgumentException>(() => new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object));
+            Assert.ThrowsExactly<ArgumentException>(() => _ = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object));
         }
 
 

--- a/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageBackendTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageBackendTests.cs
@@ -1,0 +1,230 @@
+﻿using System;
+
+using Microsoft.Extensions.Options;
+
+using PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend;
+
+namespace PxWeb.UnitTests.SavedQuery
+{
+
+    [TestClass]
+    public class SavedQueryDatabaseStorageBackendTests
+    {
+
+
+        [TestMethod]
+        public void Constructor_ShouldThrowArgumentException_WhenDatabaseVendorIsNotSupported()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "UnsupportedVendor"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+
+            // Act & Assert
+            Assert.ThrowsExactly<ArgumentException>(() => new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object));
+        }
+
+
+        [TestMethod]
+        public void Constructor_ShouldNotThrow_WhenDatabaseVendorIsSupported()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Oracle"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            // Act & Assert
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+            Assert.IsNotNull(backend);
+        }
+
+        [TestMethod]
+        public void Constructor_ShouldNotThrow_WhenDatabaseVendorIsSupported2()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Microsoft"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            // Act & Assert
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+            Assert.IsNotNull(backend);
+        }
+
+        [TestMethod]
+        public void Load_ShouldReturnEmptyString_WhenInvalidId()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Microsoft"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+
+            // Act
+
+            var result = backend.Load("invalid_id");
+
+            // Assert
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [TestMethod]
+        public void Load_ShouldThrowException_WhenNoConnectionStringSpecified()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Microsoft"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+
+            // Act & assert 
+            Assert.ThrowsExactly<InvalidOperationException>(() => backend.Load("0"));
+
+        }
+
+        [TestMethod]
+        public void UpdatedStatistics_ShouldReturnFalse_WhenInvalidId()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Microsoft"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+
+            // Act
+            var result = backend.UpdateRunStatistics("invalid_id");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void Save_ShouldReturnEmptyString_WhenNoConnectionStringSpecified()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Microsoft"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+            resolver.Setup(r => r.Resolve(It.IsAny<string>(), It.IsAny<string>(), out It.Ref<bool>.IsAny)).Returns(string.Empty);
+
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+
+            // Act
+            var result = backend.Save("", "0", "sv");
+
+            // Assert
+            Assert.AreEqual(string.Empty, result);
+
+        }
+
+    }
+}

--- a/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageOptionsTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageOptionsTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-
-using Microsoft.Extensions.Options;
-
-using PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend;
-
-namespace PxWeb.UnitTests.SavedQuery
+﻿namespace PxWeb.UnitTests.SavedQuery
 {
     [TestClass]
     public class SavedQueryDatabaseStorageOptionsTests
@@ -22,62 +16,7 @@ namespace PxWeb.UnitTests.SavedQuery
             Assert.AreEqual("Microsoft", options.DatabaseVendor);
         }
 
-        [TestMethod]
-        public void Constructor_ShouldThrowArgumentException_WhenDatabaseVendorIsNotSupported()
-        {
-            // Arrange
-            var options = new SavedQueryDatabaseStorageOptions
-            {
-                DatabaseVendor = "UnsupportedVendor"
-            };
-
-            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
-            mockStorageOptions.Setup(o => o.Value).Returns(options);
 
 
-            DataSourceOptions dataSourceOptions = new DataSourceOptions
-            {
-                DataSourceType = "Database"
-            };
-
-            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
-            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
-
-            var resolver = new Mock<ITablePathResolver>();
-
-
-            // Act & Assert
-            Assert.ThrowsException<ArgumentException>(() => new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object));
-        }
-
-
-
-        [TestMethod]
-        public void Constructor_ShouldNotThrow_WhenDatabaseVendorIsSupported()
-        {
-            // Arrange
-            var options = new SavedQueryDatabaseStorageOptions
-            {
-                DatabaseVendor = "Oracle"
-            };
-
-            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
-            mockStorageOptions.Setup(o => o.Value).Returns(options);
-
-
-            DataSourceOptions dataSourceOptions = new DataSourceOptions
-            {
-                DataSourceType = "Database"
-            };
-
-            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
-            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
-
-            var resolver = new Mock<ITablePathResolver>();
-
-            // Act & Assert
-            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
-            Assert.IsNotNull(backend);
-        }
     }
 }

--- a/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageOptionsTests.cs
+++ b/PxWeb.UnitTests/SavedQuery/SavedQueryDatabaseStorageOptionsTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+
+using Microsoft.Extensions.Options;
+
+using PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend;
+
+namespace PxWeb.UnitTests.SavedQuery
+{
+    [TestClass]
+    public class SavedQueryDatabaseStorageOptionsTests
+    {
+
+        [TestMethod]
+        public void CheckDefaultConstructor_ShouldInitializeProperties()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions();
+            // Act & Assert
+            Assert.AreEqual(string.Empty, options.ConnectionString);
+            Assert.AreEqual("default", options.TargetDatabase);
+            Assert.AreEqual("dbo", options.TableOwner);
+            Assert.AreEqual("Microsoft", options.DatabaseVendor);
+        }
+
+        [TestMethod]
+        public void Constructor_ShouldThrowArgumentException_WhenDatabaseVendorIsNotSupported()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "UnsupportedVendor"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+
+            // Act & Assert
+            Assert.ThrowsException<ArgumentException>(() => new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object));
+        }
+
+
+
+        [TestMethod]
+        public void Constructor_ShouldNotThrow_WhenDatabaseVendorIsSupported()
+        {
+            // Arrange
+            var options = new SavedQueryDatabaseStorageOptions
+            {
+                DatabaseVendor = "Oracle"
+            };
+
+            var mockStorageOptions = new Mock<IOptions<SavedQueryDatabaseStorageOptions>>();
+            mockStorageOptions.Setup(o => o.Value).Returns(options);
+
+
+            DataSourceOptions dataSourceOptions = new DataSourceOptions
+            {
+                DataSourceType = "Database"
+            };
+
+            var mockDataSourceOptions = new Mock<IOptions<DataSourceOptions>>();
+            mockDataSourceOptions.Setup(o => o.Value).Returns(dataSourceOptions);
+
+            var resolver = new Mock<ITablePathResolver>();
+
+            // Act & Assert
+            var backend = new SavedQueryDatabaseStorageBackend(mockDataSourceOptions.Object, mockStorageOptions.Object, resolver.Object);
+            Assert.IsNotNull(backend);
+        }
+    }
+}

--- a/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
+++ b/PxWeb/Code/Api2/DataSelection/SelectionHandler.cs
@@ -106,20 +106,16 @@ namespace PxWeb.Code.Api2.DataSelection
             {
 
                 var modelVariable = model.Meta.Variables.GetByCode(variable.VariableCode);
+                var valueCodes = variable.ValueCodes.ToList();
 
-                for (int i = 0; i < variable.ValueCodes.Count; i++)
+                foreach (var valueCode in valueCodes)
                 {
-                    var valueCode = variable.ValueCodes[i];
                     // Try to get the value using the code specified by the API user
                     Value? pxValue = modelVariable.Values.FirstOrDefault(x => x.Code.Equals(valueCode, System.StringComparison.InvariantCultureIgnoreCase));
 
-                    if (pxValue is null)
+                    if (!ExpandValue(ref problem, variable, modelVariable, valueCode, pxValue))
                     {
-                        return ExpandSelectionExpression(variable, modelVariable, valueCode, out problem);
-                    }
-                    else
-                    {
-                        variable.ValueCodes[i] = pxValue.Code;
+                        return false;
                     }
                 }
 
@@ -132,6 +128,29 @@ namespace PxWeb.Code.Api2.DataSelection
                 }
             }
 
+            return true;
+        }
+
+        private static bool ExpandValue(ref Problem? problem, VariableSelection variable, Variable modelVariable, string valueCode, Value? pxValue)
+        {
+            if (pxValue is null)
+            {
+                if (ExpandSelectionExpression(variable, modelVariable, valueCode, out problem))
+                {
+                    variable.ValueCodes.Remove(valueCode);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (valueCode != pxValue.Code)
+                {
+                    variable.ValueCodes[variable.ValueCodes.IndexOf(valueCode)] = pxValue.Code;
+                }
+            }
             return true;
         }
 

--- a/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/DataSource/DataSourceServiceCollectionExtensions.cs
@@ -12,6 +12,8 @@ namespace PxWeb.Code.Api2.DataSource
     {
         public static void AddPxDataSource(this IServiceCollection services, WebApplicationBuilder builder)
         {
+            builder.Services.Configure<DataSourceOptions>(builder.Configuration.GetSection("DataSource"));
+
             var dataSource = builder.Configuration.GetSection("DataSource:DataSourceType");
 
             if (dataSource.Value != null && dataSource.Value.ToUpper() == "PX")

--- a/PxWeb/Code/Api2/DataWorkflow.cs
+++ b/PxWeb/Code/Api2/DataWorkflow.cs
@@ -1,0 +1,91 @@
+﻿using System.Linq;
+
+using PCAxis.Paxiom;
+using PCAxis.Paxiom.Operations;
+
+using Px.Abstractions.Interfaces;
+
+using PxWeb.Api2.Server.Models;
+using PxWeb.Code.Api2.DataSelection;
+using PxWeb.Helper.Api2;
+
+namespace PxWeb.Code.Api2
+{
+    public class DataWorkflow : IDataWorkflow
+    {
+        private readonly IDataSource _dataSource;
+        private readonly ISelectionHandler _selectionHandler;
+
+        public DataWorkflow(IDataSource datasource, ISelectionHandler selectionHandler)
+        {
+            _dataSource = datasource;
+            _selectionHandler = selectionHandler;
+        }
+        public PXModel? Run(string tableId, string language, VariablesSelection variablesSelection, out Problem? problem)
+        {
+            //If no selection is made, return a problem and exit early
+            if (variablesSelection is null)
+            {
+                problem = ProblemUtility.MissingSelection();
+                return null;
+
+            }
+
+            // Create a builder for the table and read in the table metadata
+            var builder = _dataSource.CreateBuilder(tableId, language);
+
+            if (builder == null)
+            {
+                problem = ProblemUtility.NonExistentTable();
+                return null;
+            }
+            builder.BuildForSelection();
+
+            // Expand and verify the selections
+            if (!_selectionHandler.ExpandAndVerfiySelections(variablesSelection, builder, out problem))
+            {
+                return null;
+            }
+
+
+            Selection[]? selection = null;
+            VariablePlacementType? placment = null;
+
+            selection = _selectionHandler.Convert(variablesSelection);
+
+            if (problem is not null)
+            {
+                return null;
+            }
+
+            builder.BuildForPresentation(selection);
+
+            var model = builder.Model;
+
+            // TODO: Fix this
+            //placment = savedQuery.Selection.Placement;
+
+            if (placment is not null)
+            {
+                var descriptions = new List<PivotDescription>();
+
+                descriptions.AddRange(placment.Heading.Select(h => new PivotDescription()
+                {
+                    VariableName = model.Meta.Variables.First(v => v.Code.Equals(h, StringComparison.OrdinalIgnoreCase)).Name,
+                    VariablePlacement = PlacementType.Heading
+                }));
+
+                descriptions.AddRange(placment.Stub.Select(h => new PivotDescription()
+                {
+                    VariableName = model.Meta.Variables.First(v => v.Code == h).Name,
+                    VariablePlacement = PlacementType.Stub
+                }));
+
+                var pivot = new PCAxis.Paxiom.Operations.Pivot();
+                model = pivot.Execute(model, descriptions.ToArray());
+            }
+
+            return model;
+        }
+    }
+}

--- a/PxWeb/Code/Api2/DataWorkflow.cs
+++ b/PxWeb/Code/Api2/DataWorkflow.cs
@@ -37,6 +37,12 @@ namespace PxWeb.Code.Api2
 
             // Create a builder for the table and read in the table metadata
             var builder = _dataSource.CreateBuilder(tableId, language);
+            if (builder == null)
+            {
+                problem = ProblemUtility.NonExistentTable();
+                return null;
+            }
+            builder.BuildForSelection();
             return Run(variablesSelection, builder, out problem);
         }
 
@@ -48,6 +54,8 @@ namespace PxWeb.Code.Api2
                 problem = ProblemUtility.NonExistentTable();
                 return null;
             }
+
+            builder.BuildForSelection();
 
             var variablesSelection = _defaultSelectionAlgorithm.GetDefaultSelection(builder);
             //If no selection is made, return a problem and exit early
@@ -77,7 +85,7 @@ namespace PxWeb.Code.Api2
                 problem = ProblemUtility.NonExistentTable();
                 return null;
             }
-            builder.BuildForSelection();
+
 
             // Expand and verify the selections
             if (!_selectionHandler.ExpandAndVerfiySelections(variablesSelection, builder, out problem))

--- a/PxWeb/Code/Api2/DataWorkflow.cs
+++ b/PxWeb/Code/Api2/DataWorkflow.cs
@@ -108,7 +108,6 @@ namespace PxWeb.Code.Api2
 
             var model = builder.Model;
 
-            // TODO: Fix this
             placment = _placementHandler.GetPlacment(variablesSelection, selection, builder.Model.Meta, out problem);
 
             if (placment is not null)

--- a/PxWeb/Code/Api2/IDataWorkflow.cs
+++ b/PxWeb/Code/Api2/IDataWorkflow.cs
@@ -1,0 +1,11 @@
+﻿using PCAxis.Paxiom;
+
+using PxWeb.Api2.Server.Models;
+
+namespace PxWeb.Code.Api2
+{
+    public interface IDataWorkflow
+    {
+        PXModel? Run(string tableId, string language, VariablesSelection variablesSelection, out Problem? problem);
+    }
+}

--- a/PxWeb/Code/Api2/IDataWorkflow.cs
+++ b/PxWeb/Code/Api2/IDataWorkflow.cs
@@ -6,6 +6,7 @@ namespace PxWeb.Code.Api2
 {
     public interface IDataWorkflow
     {
-        PXModel? Run(string tableId, string language, VariablesSelection variablesSelection, out Problem? problem);
+        PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem);
+        PXModel? Run(string tableId, string language, out Problem? problem);
     }
 }

--- a/PxWeb/Code/Api2/SavedQueryBackend/DatabaseBackend/SavedQueryDatabaseStorageBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/DatabaseBackend/SavedQueryDatabaseStorageBackend.cs
@@ -1,0 +1,29 @@
+﻿using Px.Abstractions.Interfaces;
+
+namespace PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend
+{
+    public class SavedQueryDatabaseStorageBackend : ISavedQueryStorageBackend
+    {
+        private readonly ITablePathResolver _tablePathResolver;
+
+        public SavedQueryDatabaseStorageBackend(ITablePathResolver tablePathResolver)
+        {
+            _tablePathResolver = tablePathResolver;
+        }
+
+        public string Load(string id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string Save(string savedQuery, string tableId, string language)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool UpdateRunStatistics(string id)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/DatabaseBackend/SavedQueryDatabaseStorageBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/DatabaseBackend/SavedQueryDatabaseStorageBackend.cs
@@ -1,14 +1,31 @@
-﻿using Px.Abstractions.Interfaces;
+﻿using Microsoft.Extensions.Options;
+
+using Px.Abstractions.Interfaces;
 
 namespace PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend
 {
     public class SavedQueryDatabaseStorageBackend : ISavedQueryStorageBackend
     {
         private readonly ITablePathResolver _tablePathResolver;
+        private readonly string _dataSourceType;
 
-        public SavedQueryDatabaseStorageBackend(ITablePathResolver tablePathResolver)
+        public SavedQueryDatabaseStorageBackend(IOptions<DataSourceOptions> datasource, IOptions<SavedQueryDatabaseStorageOptions> savedQueryBackendOptions, ITablePathResolver tablePathResolver)
         {
             _tablePathResolver = tablePathResolver;
+            _dataSourceType = datasource.Value.DataSourceType.ToUpper();
+
+            if (string.Equals(savedQueryBackendOptions.Value.DatabaseVendor, "Oracle", StringComparison.OrdinalIgnoreCase))
+            {
+
+            }
+            else if (string.Equals(savedQueryBackendOptions.Value.DatabaseVendor, "Microsoft", StringComparison.OrdinalIgnoreCase))
+            {
+
+            }
+            else
+            {
+                throw new ArgumentException($"Database vendor '{savedQueryBackendOptions.Value.DatabaseVendor}' is not supported.");
+            }
         }
 
         public string Load(string id)

--- a/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
@@ -58,7 +58,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
             return name;
         }
 
-        public void UpdateRunStatistics(string id)
+        public bool UpdateRunStatistics(string id)
         {
             id = SavedQueryBackendProxy.SanitizeName(id);
             // Load the statistics file
@@ -67,6 +67,11 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
             if (File.Exists(statisticsFilePath))
             {
                 statistics = JsonSerializer.Deserialize<SavedQueryStats>(File.ReadAllText(statisticsFilePath));
+            }
+            else if (!File.Exists(Path.Combine(_path, id.Substring(0, _subDirectoryLength), id + ".sqa")))
+            {
+                // No saved query file exists, so we can't update the statistics
+                return false;
             }
             else
             {
@@ -80,6 +85,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
             }
 
             File.WriteAllText(statisticsFilePath, JsonSerializer.Serialize(statistics));
+            return true;
         }
     }
 }

--- a/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
@@ -25,6 +25,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
 
         public string Load(string id)
         {
+            id = SavedQueryBackendProxy.SanitizeName(id);
             var statisticsFilePath = Path.Combine(_path, id.Substring(0, _subDirectoryLength), id + ".sqa");
 
             if (File.Exists(statisticsFilePath))
@@ -59,6 +60,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
 
         public void UpdateRunStatistics(string id)
         {
+            id = SavedQueryBackendProxy.SanitizeName(id);
             // Load the statistics file
             var statisticsFilePath = Path.Combine(_path, id.Substring(0, _subDirectoryLength), id + ".sqs");
             SavedQueryStats? statistics;

--- a/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
@@ -36,7 +36,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
             return string.Empty;
         }
 
-        public string Save(string savedQuery)
+        public string Save(string savedQuery, string tableId, string language)
         {
             var name = Guid.NewGuid().ToString();
 

--- a/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SaveQueryFileStorgeBackend.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+using System.Text.Json;
+
+using Microsoft.Extensions.Options;
+
+using Px.Abstractions.Interfaces;
+
+namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
+{
+    public class SaveQueryFileStorgeBackend : ISavedQueryStorageBackend
+    {
+
+        private readonly string _path;
+        private readonly int _subDirectoryLength = 1;
+
+        public SaveQueryFileStorgeBackend(IOptions<SavedQueryFileStorageOptions> options, IPxHost host)
+        {
+            var path = options.Value.Path;
+            if (!Path.IsPathFullyQualified(path))
+            {
+                path = Path.Combine(host.RootPath, path);
+            }
+            _path = path;
+        }
+
+        public string Load(string id)
+        {
+            var statisticsFilePath = Path.Combine(_path, id.Substring(0, _subDirectoryLength), id + ".sqa");
+
+            if (File.Exists(statisticsFilePath))
+            {
+                return File.ReadAllText(statisticsFilePath);
+            }
+
+            return string.Empty;
+        }
+
+        public string Save(string savedQuery)
+        {
+            var name = Guid.NewGuid().ToString();
+
+            //Make sure the directory exists
+            var fileDirectory = Path.Combine(_path, name.Substring(0, _subDirectoryLength));
+            if (!Directory.Exists(fileDirectory))
+            {
+                Directory.CreateDirectory(fileDirectory);
+            }
+
+            // Saves the saved query to file
+            var filePath = Path.Combine(fileDirectory, name + ".sqa");
+            File.WriteAllText(filePath, savedQuery);
+
+            // Create a statistics file
+            var statisticsFilePath = Path.Combine(fileDirectory, name + ".sqs");
+            var statistics = new SavedQueryStats() { Created = DateTime.Now };
+            File.WriteAllText(statisticsFilePath, JsonSerializer.Serialize(statistics));
+            return name;
+        }
+
+        public void UpdateRunStatistics(string id)
+        {
+            // Load the statistics file
+            var statisticsFilePath = Path.Combine(_path, id.Substring(0, _subDirectoryLength), id + ".sqs");
+            SavedQueryStats? statistics;
+            if (File.Exists(statisticsFilePath))
+            {
+                statistics = JsonSerializer.Deserialize<SavedQueryStats>(File.ReadAllText(statisticsFilePath));
+            }
+            else
+            {
+                statistics = new SavedQueryStats() { Created = DateTime.Now };
+            }
+
+            if (statistics is not null)
+            {
+                statistics.UsageCount++;
+                statistics.LastUsed = DateTime.Now;
+            }
+
+            File.WriteAllText(statisticsFilePath, JsonSerializer.Serialize(statistics));
+        }
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SavedQueryStats.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/FileBackend/SavedQueryStats.cs
@@ -1,0 +1,9 @@
+﻿namespace PxWeb.Code.Api2.SavedQueryBackend.FileBackend
+{
+    public class SavedQueryStats
+    {
+        public DateTime Created { get; set; }
+        public DateTime? LastUsed { get; set; }
+        public int UsageCount { get; set; } = 0;
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/ISavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/ISavedQueryBackendProxy.cs
@@ -6,6 +6,6 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
     {
         string Save(SavedQuery savedQuery);
         SavedQuery? Load(string id);
-        void UpdateRunStatistics(string id);
+        bool UpdateRunStatistics(string id);
     }
 }

--- a/PxWeb/Code/Api2/SavedQueryBackend/ISavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/ISavedQueryBackendProxy.cs
@@ -1,0 +1,11 @@
+﻿using PxWeb.Api2.Server.Models;
+
+namespace PxWeb.Code.Api2.SavedQueryBackend
+{
+    public interface ISavedQueryBackendProxy
+    {
+        string Save(SavedQuery savedQuery);
+        SavedQuery? Load(string id);
+        void UpdateRunStatistics(string id);
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -40,10 +40,10 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
             return _backend.Save(savedQueryString);
         }
 
-        public void UpdateRunStatistics(string id)
+        public bool UpdateRunStatistics(string id)
         {
             var cleanId = SanitizeName(id);
-            _backend.UpdateRunStatistics(cleanId);
+            return _backend.UpdateRunStatistics(cleanId);
         }
 
         public static string SanitizeName(string id)

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -23,7 +23,15 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
             {
                 return null;
             }
-            return JsonSerializer.Deserialize<SavedQuery>(savedQueryString);
+
+            var savedQuery = JsonSerializer.Deserialize<SavedQuery>(savedQueryString);
+
+            if (savedQuery is not null)
+            {
+                savedQuery.Id = cleanId;
+            }
+
+            return savedQuery;
         }
 
         public string Save(SavedQuery savedQuery)

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -37,7 +37,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
         public string Save(SavedQuery savedQuery)
         {
             var savedQueryString = JsonSerializer.Serialize(savedQuery);
-            return _backend.Save(savedQueryString);
+            return _backend.Save(savedQueryString, savedQuery.TableId, savedQuery.Language);
         }
 
         public bool UpdateRunStatistics(string id)

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -16,7 +16,8 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
 
         public SavedQuery? Load(string id)
         {
-            var savedQueryString = _backend.Load(id);
+            var cleanId = SanitizeName(id);
+            var savedQueryString = _backend.Load(cleanId);
             if (string.IsNullOrEmpty(savedQueryString))
             {
                 return null;
@@ -32,7 +33,13 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
 
         public void UpdateRunStatistics(string id)
         {
-            _backend.UpdateRunStatistics(id);
+            var cleanId = SanitizeName(id);
+            _backend.UpdateRunStatistics(cleanId);
+        }
+
+        private static string SanitizeName(string id)
+        {
+            return id.Replace("/", "_").Replace("\\", "_").Replace(".", "_");
         }
     }
 }

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -1,0 +1,38 @@
+﻿using System.Text.Json;
+
+using Px.Abstractions.Interfaces;
+
+using PxWeb.Api2.Server.Models;
+
+namespace PxWeb.Code.Api2.SavedQueryBackend
+{
+    public class SavedQueryBackendProxy : ISavedQueryBackendProxy
+    {
+        private readonly ISavedQueryStorageBackend _backend;
+        public SavedQueryBackendProxy(ISavedQueryStorageBackend backend)
+        {
+            _backend = backend;
+        }
+
+        public SavedQuery? Load(string id)
+        {
+            var savedQueryString = _backend.Load(id);
+            if (string.IsNullOrEmpty(savedQueryString))
+            {
+                return null;
+            }
+            return JsonSerializer.Deserialize<SavedQuery>(savedQueryString);
+        }
+
+        public string Save(SavedQuery savedQuery)
+        {
+            var savedQueryString = JsonSerializer.Serialize(savedQuery);
+            return _backend.Save(savedQueryString);
+        }
+
+        public void UpdateRunStatistics(string id)
+        {
+            _backend.UpdateRunStatistics(id);
+        }
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendProxy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.RegularExpressions;
 
 using Px.Abstractions.Interfaces;
 
@@ -37,9 +38,9 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
             _backend.UpdateRunStatistics(cleanId);
         }
 
-        private static string SanitizeName(string id)
+        public static string SanitizeName(string id)
         {
-            return id.Replace("/", "_").Replace("\\", "_").Replace(".", "_");
+            return Regex.Replace(id, @"[^a-zA-Z0-9-]", "", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
         }
     }
 }

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Px.Abstractions.Interfaces;
 
+using PxWeb.Code.Api2.SavedQueryBackend.DatabaseBackend;
 using PxWeb.Code.Api2.SavedQueryBackend.FileBackend;
 
 namespace PxWeb.Code.Api2.SavedQueryBackend
@@ -15,7 +16,8 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
 
             if (backend.Equals("Database", StringComparison.OrdinalIgnoreCase))
             {
-                // Configure database backend
+                builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection("SavedQuery:" + SavedQueryDatabaseStorageOptions.SectionName));
+                builder.Services.AddTransient<ISavedQueryStorageBackend, SavedQueryDatabaseStorageBackend>();
             }
             else
             {

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+using Px.Abstractions.Interfaces;
+
+using PxWeb.Code.Api2.SavedQueryBackend.FileBackend;
+
+namespace PxWeb.Code.Api2.SavedQueryBackend
+{
+    public static class SavedQueryBackendServiceCollectionExtensions
+    {
+        public static void AddSavedQuery(this IServiceCollection services, WebApplicationBuilder builder)
+        {
+            var backend = builder.Configuration.GetSection("SavedQuery:Backend");
+
+            if (backend.Value != null && backend.Value.ToUpper() == "DATABASE")
+            {
+                // Configure database backend
+            }
+            else
+            {
+                // File storage backend is also the fallback
+                builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection("SavedQuery:" + SavedQueryFileStorageOptions.SectionName));
+                builder.Services.AddTransient<ISavedQueryStorageBackend, SaveQueryFileStorgeBackend>();
+
+            }
+
+        }
+    }
+}

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
@@ -11,9 +11,9 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
     {
         public static void AddSavedQuery(this IServiceCollection services, WebApplicationBuilder builder)
         {
-            var backend = builder.Configuration.GetSection("SavedQuery:Backend");
+            var backend = builder.Configuration.GetSection("SavedQuery:Backend").Value ?? "File";
 
-            if (backend.Value != null && backend.Value.ToUpper() == "DATABASE")
+            if (backend.Equals("Database", StringComparison.OrdinalIgnoreCase))
             {
                 // Configure database backend
             }
@@ -22,7 +22,6 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
                 // File storage backend is also the fallback
                 builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection("SavedQuery:" + SavedQueryFileStorageOptions.SectionName));
                 builder.Services.AddTransient<ISavedQueryStorageBackend, SaveQueryFileStorgeBackend>();
-
             }
 
         }

--- a/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
+++ b/PxWeb/Code/Api2/SavedQueryBackend/SavedQueryBackendServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace PxWeb.Code.Api2.SavedQueryBackend
 
             if (backend.Equals("Database", StringComparison.OrdinalIgnoreCase))
             {
-                builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection("SavedQuery:" + SavedQueryDatabaseStorageOptions.SectionName));
+                builder.Services.Configure<SavedQueryDatabaseStorageOptions>(builder.Configuration.GetSection("SavedQuery:" + SavedQueryDatabaseStorageOptions.SectionName));
                 builder.Services.AddTransient<ISavedQueryStorageBackend, SavedQueryDatabaseStorageBackend>();
             }
             else

--- a/PxWeb/Config/Api2/DataSourceOptions.cs
+++ b/PxWeb/Config/Api2/DataSourceOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public class DataSourceOptions
+    {
+        public string DataSourceType { get; set; } = "PX";
+    }
+}

--- a/PxWeb/Config/Api2/SavedQueryDatabaseStorageOptions.cs
+++ b/PxWeb/Config/Api2/SavedQueryDatabaseStorageOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public class SavedQueryDatabaseStorageOptions
+    {
+        public const string SectionName = "DatabaseStorage";
+
+        public SavedQueryDatabaseStorageOptions()
+        {
+            ConnectionString = string.Empty;
+            TargetDatabase = "default";
+            TableOwner = "dbo";
+        }
+
+        public string ConnectionString { get; set; }
+        public string TargetDatabase { get; set; }
+        public string TableOwner { get; set; }
+
+        public string DatabaseVendor { get; set; }
+
+    }
+}

--- a/PxWeb/Config/Api2/SavedQueryDatabaseStorageOptions.cs
+++ b/PxWeb/Config/Api2/SavedQueryDatabaseStorageOptions.cs
@@ -9,12 +9,12 @@
             ConnectionString = string.Empty;
             TargetDatabase = "default";
             TableOwner = "dbo";
+            DatabaseVendor = "Microsoft";
         }
 
         public string ConnectionString { get; set; }
         public string TargetDatabase { get; set; }
         public string TableOwner { get; set; }
-
         public string DatabaseVendor { get; set; }
 
     }

--- a/PxWeb/Config/Api2/SavedQueryFileStorageOptions.cs
+++ b/PxWeb/Config/Api2/SavedQueryFileStorageOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public class SavedQueryFileStorageOptions
+    {
+        public const string SectionName = "SavedQueryFileStorage";
+        public SavedQueryFileStorageOptions()
+        {
+            Path = "saved-queries";
+        }
+
+        public string Path { get; set; }
+
+    }
+}

--- a/PxWeb/Config/Api2/SavedQueryFileStorageOptions.cs
+++ b/PxWeb/Config/Api2/SavedQueryFileStorageOptions.cs
@@ -2,7 +2,7 @@
 {
     public class SavedQueryFileStorageOptions
     {
-        public const string SectionName = "SavedQueryFileStorage";
+        public const string SectionName = "FileStorage";
         public SavedQueryFileStorageOptions()
         {
             Path = "saved-queries";

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -41,10 +41,12 @@ namespace PxWeb.Controllers.Api2
 
             // 1. Make sure that the SavedQuery is ok and that it results in a valid output.
             var builder = _dataSource.CreateBuilder(savedQuery.TableId, savedQuery.Language);
+
             if (builder == null)
             {
                 return NotFound(ProblemUtility.NonExistentTable());
             }
+            builder.BuildForSelection();
 
             Selection[]? selection = null;
             VariablePlacementType? placment = null;

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -21,9 +21,9 @@ namespace PxWeb.Controllers.Api2
         private readonly ISavedQueryBackendProxy _savedQueryBackendProxy;
         private readonly ISerializeManager _serializeManager;
         private readonly IDataWorkflow _dataWorkflow;
-        private readonly ILogger _logger;
+        private readonly ILogger<SavedQueryApiController> _logger;
 
-        public SavedQueryApiController(IDataWorkflow dataWorkflow, ISavedQueryBackendProxy savedQueryStorageBackend, ISerializeManager serializeManager, IOptions<PxApiConfigurationOptions> configOptions, ILogger logger)
+        public SavedQueryApiController(IDataWorkflow dataWorkflow, ISavedQueryBackendProxy savedQueryStorageBackend, ISerializeManager serializeManager, IOptions<PxApiConfigurationOptions> configOptions, ILogger<SavedQueryApiController> logger)
         {
             _dataWorkflow = dataWorkflow;
             _savedQueryBackendProxy = savedQueryStorageBackend;

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -100,6 +100,8 @@ namespace PxWeb.Controllers.Api2
                 return NotFound();
             }
 
+            _savedQueryBackendProxy.UpdateRunStatistics(id);
+
             // 3. Override parameters to the SavedQuery
             bool paramError;
             string outputFormatStr;

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -66,7 +66,7 @@ namespace PxWeb.Controllers.Api2
 
         public override IActionResult GetSaveQuery([FromRoute(Name = "id"), Required] string id)
         {
-            if (id.Contains("..") || id.Contains("/") || id.Contains("\\"))
+            if (id.Contains("..") || id.Contains('/') || id.Contains('\\'))
             {
                 // TODO: Fix error message
                 return BadRequest("");
@@ -85,7 +85,7 @@ namespace PxWeb.Controllers.Api2
             Problem? problem;
 
             // 0. Validate the input
-            if (id.Contains("..") || id.Contains("/") || id.Contains("\\"))
+            if (id.Contains("..") || id.Contains('/') || id.Contains('\\'))
             {
                 // TODO: Fix error message
                 return BadRequest("");

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -83,6 +83,8 @@ namespace PxWeb.Controllers.Api2
         {
             Problem? problem;
 
+            //TODO: Validate lang and outputFormat paramters
+
             // 0. Validate the input
             if (id.Contains("..") || id.Contains('/') || id.Contains('\\'))
             {
@@ -96,6 +98,8 @@ namespace PxWeb.Controllers.Api2
                 // 2. If the SavedQuery is not found return 404 Not Found
                 return NotFound(ProblemUtility.NonExistentSavedQuery());
             }
+
+            //TODO: Replace lang and outputFormat in saved query if specified as pramaters
 
             _savedQueryBackendProxy.UpdateRunStatistics(id);
 

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 using PCAxis.Paxiom;
 using PCAxis.Paxiom.Operations;
@@ -11,6 +13,7 @@ using Px.Abstractions.Interfaces;
 using PxWeb.Api2.Server.Models;
 using PxWeb.Code.Api2.DataSelection;
 using PxWeb.Code.Api2.SavedQueryBackend;
+using PxWeb.Code.Api2.Serialization;
 using PxWeb.Helper.Api2;
 
 namespace PxWeb.Controllers.Api2
@@ -18,16 +21,19 @@ namespace PxWeb.Controllers.Api2
     [ApiController]
     public class SavedQueryApiController : PxWeb.Api2.Server.Controllers.SavedQueriesApiController
     {
-
+        private readonly PxApiConfigurationOptions _configOptions;
         private readonly ISelectionHandler _selectionHandler;
         private readonly IDataSource _dataSource;
         private readonly ISavedQueryBackendProxy _savedQueryBackendProxy;
+        private readonly ISerializeManager _serializeManager;
 
-        public SavedQueryApiController(IDataSource dataSource, ISelectionHandler selectionHandler, ISavedQueryBackendProxy savedQueryStorageBackend)
+        public SavedQueryApiController(IDataSource dataSource, ISelectionHandler selectionHandler, ISavedQueryBackendProxy savedQueryStorageBackend, ISerializeManager serializeManager, IOptions<PxApiConfigurationOptions> configOptions)
         {
             _dataSource = dataSource;
             _selectionHandler = selectionHandler;
             _savedQueryBackendProxy = savedQueryStorageBackend;
+            _serializeManager = serializeManager;
+            _configOptions = configOptions.Value;
         }
 
         public override IActionResult CreateSaveQuery([FromBody] SavedQuery? savedQuery)
@@ -133,13 +139,101 @@ namespace PxWeb.Controllers.Api2
 
         public override IActionResult RunSaveQuery([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "outputFormat")] OutputFormatType? outputFormat, [FromQuery(Name = "outputFormatParams")] List<OutputFormatParamType>? outputFormatParams)
         {
-            //TODO: Implement
+            Problem? problem;
+
+            // 0. Validate the input
+            if (id.Contains("..") || id.Contains("/") || id.Contains("\\"))
+            {
+                // TODO: Fix error message
+                return BadRequest("");
+            }
+
             // 1. Get the SavedQuery from the database/file.
-            // 2. If the SavedQuery is not found return 404 Not Found
+            var savedQuery = _savedQueryBackendProxy.Load(id);
+            if (savedQuery is null)
+            {
+                // 2. If the SavedQuery is not found return 404 Not Found
+                //TODO: Fix error message
+                return NotFound();
+            }
+
             // 3. Apply parameters to the SavedQuery
+            if (outputFormat is not null)
+            {
+                savedQuery.OutputFormat = outputFormat.Value;
+            }
+            if (outputFormatParams is not null)
+            {
+                savedQuery.OutputFormatParams = outputFormatParams;
+            }
+
             // 4. Run the SavedQuery
+            var builder = _dataSource.CreateBuilder(savedQuery.TableId, savedQuery.Language);
+
+            if (builder == null)
+            {
+                return NotFound(ProblemUtility.NonExistentTable());
+            }
+            builder.BuildForSelection();
+
+            Selection[]? selection = null;
+            VariablePlacementType? placment = null;
+
+            var variablesSelection = savedQuery.Selection;
+
+
+            if (!_selectionHandler.ExpandAndVerfiySelections(variablesSelection, builder, out problem))
+            {
+                return BadRequest(problem);
+            }
+
+            selection = _selectionHandler.Convert(variablesSelection);
+
+            if (problem is not null)
+            {
+                return BadRequest(problem);
+            }
+
+            builder.BuildForPresentation(selection);
+
+            var model = builder.Model;
+
+            placment = savedQuery.Selection.Placement;
+
+            if (placment is not null)
+            {
+                var descriptions = new List<PivotDescription>();
+
+                descriptions.AddRange(placment.Heading.Select(h => new PivotDescription()
+                {
+                    VariableName = model.Meta.Variables.First(v => v.Code.Equals(h, StringComparison.OrdinalIgnoreCase)).Name,
+                    VariablePlacement = PlacementType.Heading
+                }));
+
+                descriptions.AddRange(placment.Stub.Select(h => new PivotDescription()
+                {
+                    VariableName = model.Meta.Variables.First(v => v.Code == h).Name,
+                    VariablePlacement = PlacementType.Stub
+                }));
+
+                var pivot = new PCAxis.Paxiom.Operations.Pivot();
+                model = pivot.Execute(model, descriptions.ToArray());
+            }
+
             // 5. Return the result
-            throw new NotImplementedException();
+
+            bool paramError;
+            string outputFormatStr;
+            List<string> outputFormatParamsStr;
+
+            (outputFormatStr, outputFormatParamsStr) = OutputParameterUtil.TranslateOutputParamters(outputFormat, _configOptions.DefaultOutputFormat, outputFormatParams, out paramError);
+
+            var serializationInfo = _serializeManager.GetSerializer(outputFormatStr, model.Meta.CodePage, outputFormatParamsStr);
+
+            Response.ContentType = serializationInfo.ContentType;
+            Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
+            serializationInfo.Serializer.Serialize(model, Response.Body);
+            return Ok();
         }
 
     }

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -115,6 +115,11 @@ namespace PxWeb.Controllers.Api2
 
         public override IActionResult GetSaveQuery([FromRoute(Name = "id"), Required] string id)
         {
+            if (id.Contains("..") || id.Contains("/") || id.Contains("\\"))
+            {
+                // TODO: Fix error message
+                return BadRequest("");
+            }
             var savedQuery = _savedQueryBackendProxy.Load(id);
             if (savedQuery is null)
             {

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -40,7 +40,9 @@ namespace PxWeb.Controllers.Api2
                 //TODO Fix error message
                 return BadRequest("The request body is empty.");
             }
-            var variablesSelection = savedQuery.Selection;
+
+            // Create a copy of the selection to be able to expand it
+            var variablesSelection = SelectionUtil.Copy(savedQuery.Selection);
 
             // 1. Make sure that the SavedQuery is ok and that it results in a valid output.
             var builder = _dataSource.CreateBuilder(savedQuery.TableId, savedQuery.Language);

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -83,8 +83,6 @@ namespace PxWeb.Controllers.Api2
         {
             Problem? problem;
 
-            //TODO: Validate lang and outputFormat paramters
-
             // 0. Validate the input
             if (id.Contains("..") || id.Contains('/') || id.Contains('\\'))
             {
@@ -98,8 +96,6 @@ namespace PxWeb.Controllers.Api2
                 // 2. If the SavedQuery is not found return 404 Not Found
                 return NotFound(ProblemUtility.NonExistentSavedQuery());
             }
-
-            //TODO: Replace lang and outputFormat in saved query if specified as pramaters
 
             _savedQueryBackendProxy.UpdateRunStatistics(id);
 

--- a/PxWeb/Helper/Api2/ProblemUtility.cs
+++ b/PxWeb/Helper/Api2/ProblemUtility.cs
@@ -105,5 +105,35 @@ namespace PxWeb.Helper.Api2
             p.Title = "Unsupported output format";
             return p;
         }
+
+        public static Problem NonExistentSavedQuery()
+        {
+            Problem p = new Problem();
+            p.Type = "Parameter error";
+            p.Detail = "Saved query not found";
+            p.Status = 404;
+            p.Title = "Saved query not found";
+            return p;
+        }
+
+        public static Problem InternalErrorCreateSavedQuery()
+        {
+            Problem p = new Problem();
+            p.Type = "Create saved query";
+            p.Detail = "Internal error! Could not create saved query";
+            p.Status = 400;
+            p.Title = "Internal error! Could not create saved query";
+            return p;
+        }
+
+        public static Problem NoQuerySpecified()
+        {
+            Problem p = new Problem();
+            p.Type = "Create saved query";
+            p.Detail = "No query specified";
+            p.Status = 400;
+            p.Title = "No query specified";
+            return p;
+        }
     }
 }

--- a/PxWeb/Helper/Api2/SelectionUtil.cs
+++ b/PxWeb/Helper/Api2/SelectionUtil.cs
@@ -129,6 +129,28 @@ namespace PxWeb.Helper.Api2
             return variablesSelection is null || !HasSelection(variablesSelection);
         }
 
+        public static VariablesSelection Copy(VariablesSelection selection)
+        {
+            var copy = new VariablesSelection();
+            copy.Placement = new VariablePlacementType();
+            if (selection.Placement is not null)
+            {
+                copy.Placement.Heading = new List<string>(selection.Placement.Heading);
+                copy.Placement.Stub = new List<string>(selection.Placement.Stub);
+            }
+            copy.Selection = new List<VariableSelection>();
+            foreach (var variableSelection in selection.Selection)
+            {
+                var newVariableSelection = new VariableSelection();
+                newVariableSelection.CodeList = variableSelection.CodeList;
+                newVariableSelection.VariableCode = variableSelection.VariableCode;
+                newVariableSelection.ValueCodes = new List<string>(variableSelection.ValueCodes);
+                copy.Selection.Add(newVariableSelection);
+            }
+            return copy;
+        }
+
+
         /// <summary>
         /// Check if there is any selection in the VariablesSelection
         /// </summary>

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -81,6 +81,7 @@ namespace PxWeb
             builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
             builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection(SavedQueryFileStorageOptions.SectionName));
 
+            builder.Services.AddTransient<IDataWorkflow, DataWorkflow>();
             builder.Services.AddTransient<ISavedQueryStorageBackend, SaveQueryFileStorgeBackend>();
             builder.Services.AddTransient<ISavedQueryBackendProxy, SavedQueryBackendProxy>();
             builder.Services.AddTransient<IPxApiConfigurationService, PxApiConfigurationService>();

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -23,7 +23,6 @@ using PxWeb.Code.Api2.DataSelection;
 using PxWeb.Code.Api2.DataSource;
 using PxWeb.Code.Api2.NewtonsoftConfiguration;
 using PxWeb.Code.Api2.SavedQueryBackend;
-using PxWeb.Code.Api2.SavedQueryBackend.FileBackend;
 using PxWeb.Code.Api2.Serialization;
 using PxWeb.Code.BackgroundWorker;
 using PxWeb.Filters.Api2;
@@ -79,10 +78,10 @@ namespace PxWeb
             builder.Services.Configure<AdminProtectionConfigurationOptions>(builder.Configuration.GetSection("AdminProtection"));
             builder.Services.Configure<CacheMiddlewareConfigurationOptions>(builder.Configuration.GetSection("CacheMiddleware"));
             builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
-            builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection(SavedQueryFileStorageOptions.SectionName));
+
+            builder.Services.AddSavedQuery(builder);
 
             builder.Services.AddTransient<IDataWorkflow, DataWorkflow>();
-            builder.Services.AddTransient<ISavedQueryStorageBackend, SaveQueryFileStorgeBackend>();
             builder.Services.AddTransient<ISavedQueryBackendProxy, SavedQueryBackendProxy>();
             builder.Services.AddTransient<IPxApiConfigurationService, PxApiConfigurationService>();
             builder.Services.AddTransient<IAdminProtectionConfigurationService, AdminProtectionConfigurationService>();

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -22,6 +22,8 @@ using PxWeb.Code.Api2.Cache;
 using PxWeb.Code.Api2.DataSelection;
 using PxWeb.Code.Api2.DataSource;
 using PxWeb.Code.Api2.NewtonsoftConfiguration;
+using PxWeb.Code.Api2.SavedQueryBackend;
+using PxWeb.Code.Api2.SavedQueryBackend.FileBackend;
 using PxWeb.Code.Api2.Serialization;
 using PxWeb.Code.BackgroundWorker;
 using PxWeb.Filters.Api2;
@@ -77,7 +79,10 @@ namespace PxWeb
             builder.Services.Configure<AdminProtectionConfigurationOptions>(builder.Configuration.GetSection("AdminProtection"));
             builder.Services.Configure<CacheMiddlewareConfigurationOptions>(builder.Configuration.GetSection("CacheMiddleware"));
             builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
+            builder.Services.Configure<SavedQueryFileStorageOptions>(builder.Configuration.GetSection(SavedQueryFileStorageOptions.SectionName));
 
+            builder.Services.AddTransient<ISavedQueryStorageBackend, SaveQueryFileStorgeBackend>();
+            builder.Services.AddTransient<ISavedQueryBackendProxy, SavedQueryBackendProxy>();
             builder.Services.AddTransient<IPxApiConfigurationService, PxApiConfigurationService>();
             builder.Services.AddTransient<IAdminProtectionConfigurationService, AdminProtectionConfigurationService>();
             builder.Services.AddTransient<ICacheMiddlewareConfigurationService, CacheMiddlewareConfigurationService>();

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.7.0" />
-    <PackageReference Include="PcAxis.Sql" Version="1.2.9" />
+    <PackageReference Include="PcAxis.Sql" Version="1.4.0" />
     <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -9,9 +9,15 @@
     }
   },
   "SavedQuery": {
-    "Backend": "File",
-    "SavedQueryFileStorage": {
-      "Path":  "sq"
+    "Backend": "Database",
+    "FileStorage": {
+      "Path": "sq"
+    },
+    "DatabaseStorage": {
+      "TagetDatabase": "public",
+      "DatabaseVendor": "Microsoft",
+      "ConnectionString": "",
+      "TableOwner":  "dbo"
     }
   },
   "PxApiConfiguration": {

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -17,7 +17,7 @@
       "TagetDatabase": "public",
       "DatabaseVendor": "Microsoft",
       "ConnectionString": "",
-      "TableOwner":  "dbo"
+      "TableOwner": "dbo"
     }
   },
   "PxApiConfiguration": {

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -1,6 +1,6 @@
 {
   "DataSource": {
-    "DataSourceType": "CNMM",
+    "DataSourceType": "PX",
     "PX": {
       "StrictAggregations": "true"
     },

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -8,6 +8,12 @@
       "DatabaseID": "ssd"
     }
   },
+  "SavedQuery": {
+    "Backend": "File",
+    "SavedQueryFileStorage": {
+      "Path":  "sq"
+    }
+  },
   "PxApiConfiguration": {
     "Languages": [
       {

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -1,6 +1,6 @@
 {
   "DataSource": {
-    "DataSourceType": "PX",
+    "DataSourceType": "CNMM",
     "PX": {
       "StrictAggregations": "true"
     },

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -9,7 +9,7 @@
     }
   },
   "SavedQuery": {
-    "Backend": "Database",
+    "Backend": "File",
     "FileStorage": {
       "Path": "sq"
     },

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -97,6 +97,17 @@ namespace PxWebApi_Mvc.Tests
         }
 
         [TestMethod]
+        public async Task GetSavedQuery_WhenHavingDots_ShoudlReturnFileNotFound()
+        {
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var response = await client.GetAsync(@"/savedqueries/..\tab002");
+
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [TestMethod]
         public async Task GetSavedQuery_WhenOK_ShoudlReturnSameQuery()
         {
             // Arrange
@@ -123,6 +134,27 @@ namespace PxWebApi_Mvc.Tests
 
             Assert.AreEqual("en", actualQuery.Language);
             Assert.AreEqual("*", actualQuery.Selection.Selection.FirstOrDefault(v => v.VariableCode == "REGION")?.ValueCodes[0]);
+
+        }
+
+        [TestMethod]
+        public async Task GetSavedQueryData_WhenOK_ShoudlReturnOK()
+        {
+            // Arrange
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var content = new StringContent(SavedQuery, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/savedqueries", content);
+
+            var rawQuery = await response.Content.ReadAsStringAsync();
+            var query = JsonConvert.DeserializeObject<SavedQuery>(rawQuery);
+
+            // Act
+            response = await client.GetAsync($"/savedqueries/{query?.Id}/data");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         }
     }

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -156,5 +156,33 @@ namespace PxWebApi_Mvc.Tests
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
+
+        [TestMethod]
+        public async Task GetSavedQueryData_WhenIdWithDots_ShoudlReturnBadRequest()
+        {
+            // Arrange
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            // Act
+            var response = await client.GetAsync($"/savedqueries/..test/data");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetSavedQueryData_WhenBadId_ShoudlReturnNotFound()
+        {
+            // Arrange
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            // Act
+            var response = await client.GetAsync($"/savedqueries/no-id/data");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
     }
 }

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -1,0 +1,127 @@
+﻿using System.Net;
+using System.Text;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+
+using Newtonsoft.Json;
+
+using PxWeb;
+using PxWeb.Api2.Server.Models;
+
+namespace PxWebApi_Mvc.Tests
+{
+    [TestClass]
+    public class SavedQueryApiControllerTests
+    {
+        private const string SavedQuery = @"{
+                            ""language"": ""en"",
+                            ""tableId"": ""TAB001"",
+                            ""outputFormat"": ""px"",
+                            ""outputFormatParams"": [],
+                            ""selection"": {""selection"": [
+                                {
+                                    ""variableCode"": ""ContentsCode"",
+                                    ""valueCodes"": [
+                                        ""HNMGA""
+                                    ]
+                                },
+                                {
+                                    ""variableCode"": ""TIME"",
+                                    ""valueCodes"": [
+                                        ""2001""
+                                    ]
+                                },
+                                {
+                                    ""variableCode"": ""REGION"",
+                                    ""valueCodes"": [
+                                        ""*""
+                                    ]
+                                },
+                                {
+                                    ""variableCode"": ""SEX"",
+                                    ""valueCodes"": [
+                                        ""F"",
+                                        ""M""
+                                    ]
+                                },
+                                {
+                                    ""variableCode"": ""age"",
+                                    ""valueCodes"": [""Total""],
+
+                                }
+                            ]}
+                        }";
+        [TestMethod]
+        public async Task CreateSavedQuery_WhenOK_ShoudlReturnSameQueryWithId()
+        {
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var content = new StringContent(SavedQuery, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/savedqueries", content);
+
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+
+            var rawActual = await response.Content.ReadAsStringAsync();
+            var actualQuery = JsonConvert.DeserializeObject<SavedQuery>(rawActual);
+
+            Assert.IsNotNull(actualQuery);
+            Assert.IsNotNull(actualQuery.Id);
+
+        }
+
+        [TestMethod]
+        public async Task CreateSavedQuery_WhenNotOK_ShoudlReturnBadRequest()
+        {
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var content = new StringContent("", Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/savedqueries", content);
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+
+        }
+
+        [TestMethod]
+        public async Task GetSavedQuery_WhenNotOK_ShoudlReturnFileNotFound()
+        {
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var response = await client.GetAsync("/savedqueries/no-id");
+
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetSavedQuery_WhenOK_ShoudlReturnSameQuery()
+        {
+            // Arrange
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            var content = new StringContent(SavedQuery, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/savedqueries", content);
+
+            var rawQuery = await response.Content.ReadAsStringAsync();
+            var query = JsonConvert.DeserializeObject<SavedQuery>(rawQuery);
+
+            // Act
+            response = await client.GetAsync($"/savedqueries/{query?.Id}");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            var rawActual = await response.Content.ReadAsStringAsync();
+            var actualQuery = JsonConvert.DeserializeObject<SavedQuery>(rawActual);
+
+            Assert.IsNotNull(actualQuery);
+            Assert.IsNotNull(actualQuery.Id);
+            Assert.AreEqual(query?.Id, actualQuery.Id);
+
+            Assert.AreEqual("en", actualQuery.Language);
+            Assert.AreEqual("*", actualQuery.Selection.Selection.FirstOrDefault(v => v.VariableCode == "REGION")?.ValueCodes[0]);
+
+        }
+    }
+}

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -155,7 +155,6 @@ namespace PxWebApi_Mvc.Tests
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-
         }
     }
 }

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -18,7 +18,9 @@ namespace PxWebApi_Mvc.Tests
                             ""tableId"": ""TAB001"",
                             ""outputFormat"": ""px"",
                             ""outputFormatParams"": [],
-                            ""selection"": {""selection"": [
+                            ""selection"": {
+                                ""placement"": { ""heading"": [""ContentsCode""], ""stub"":[]},
+                                ""selection"": [
                                 {
                                     ""variableCode"": ""ContentsCode"",
                                     ""valueCodes"": [

--- a/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
+++ b/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
@@ -80,5 +80,21 @@ namespace PxWebApi_Mvc.Tests
 
         }
 
+        [TestMethod]
+        public async Task GetTableData_WhenDefault_ShoudlReturnOK()
+        {
+            // Arrange
+            await using var application = new WebApplicationFactory<Program>();
+            using var client = application.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/tables/tab003/data?lang=en");
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+
+        }
+
     }
 }


### PR DESCRIPTION
Added the `Saved Query` feature to the API. 

Which can store, run and view saved queries. 

Two different storage backends are implemented. File system and database. The File system is used as the default backend and stores the files in sub directories under `/wwwroot/sq/`.
