### PR TITLE
Bugfix a case insensitive compare on the pivot to stub method

### DIFF
--- a/PxWeb/Code/Api2/DataWorkflow.cs
+++ b/PxWeb/Code/Api2/DataWorkflow.cs
@@ -125,9 +125,10 @@ namespace PxWeb.Code.Api2
                     VariablePlacement = PlacementType.Heading
                 }));
 
+
                 descriptions.AddRange(placment.Stub.Select(h => new PivotDescription()
                 {
-                    VariableName = model.Meta.Variables.First(v => v.Code == h).Name,
+                    VariableName = model.Meta.Variables.First(v => v.Code.Equals(h, StringComparison.OrdinalIgnoreCase)).Name,
                     VariablePlacement = PlacementType.Stub
                 }));
 


### PR DESCRIPTION
The code for comparing variables the should be in the `Stub` was case sensitive change this to be case insensitive.
