### PR TITLE
Update PCAxis.Serializers package version

### DIFF
--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
-    <PackageReference Include="PCAxis.Serializers" Version="1.7.0" />
+    <PackageReference Include="PCAxis.Serializers" Version="1.9.0" />
     <PackageReference Include="PcAxis.Sql" Version="1.4.1" />
     <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />


### PR DESCRIPTION
Updated the `PCAxis.Serializers` package from version `1.7.0` to `1.9.0` in the `PxWeb.csproj` project file.