### PR TITLE
Fix for losing file name when serving from cache

### DIFF
--- a/PxWeb/Code/Api2/Cache/CachedResponse.cs
+++ b/PxWeb/Code/Api2/Cache/CachedResponse.cs
@@ -2,14 +2,17 @@
 {
     public class CachedResponse
     {
-        public byte[] content { get; set; }
-        public string? contentType { get; set; }
-        public int responseCode { get; set; }
-        public CachedResponse(byte[] content, string? responseType, int responseCode)
+        public byte[] Content { get; set; }
+        public string? ContentType { get; set; }
+        public int ResponseCode { get; set; }
+        public string ContentDisposition { get; set; }
+
+        public CachedResponse(byte[] content, string? responseType, int responseCode, string contentDisposition)
         {
-            this.content = content;
-            contentType = responseType;
-            this.responseCode = responseCode;
+            this.Content = content;
+            ContentType = responseType;
+            this.ResponseCode = responseCode;
+            ContentDisposition = contentDisposition;
         }
     }
 }

--- a/PxWeb/Middleware/CacheMiddleware.cs
+++ b/PxWeb/Middleware/CacheMiddleware.cs
@@ -37,7 +37,8 @@ namespace PxWeb.Middleware
 
                 string? contentType = httpContext.Response.ContentType;
                 int responseCode = httpContext.Response.StatusCode;
-                CachedResponse response = new CachedResponse(body, contentType, responseCode);
+                string contentDisposition = httpContext.Response.Headers["Content-Disposition"].ToString();
+                CachedResponse response = new CachedResponse(body, contentType, responseCode, contentDisposition);
                 return response;
             }
         }
@@ -90,10 +91,14 @@ namespace PxWeb.Middleware
                 response = cached;
             }
 
-            httpContext.Response.ContentType = response.contentType;
-            httpContext.Response.StatusCode = response.responseCode;
+            httpContext.Response.ContentType = response.ContentType;
+            httpContext.Response.StatusCode = response.ResponseCode;
+            if (!string.IsNullOrEmpty(response.ContentDisposition))
+            {
+                httpContext.Response.Headers.Append("Content-Disposition", response.ContentDisposition);
+            }
 
-            await httpContext.Response.Body.WriteAsync(response.content);
+            await httpContext.Response.Body.WriteAsync(response.Content);
         }
     }
 

--- a/PxWeb/Middleware/CacheMiddleware.cs
+++ b/PxWeb/Middleware/CacheMiddleware.cs
@@ -37,7 +37,9 @@ namespace PxWeb.Middleware
 
                 string? contentType = httpContext.Response.ContentType;
                 int responseCode = httpContext.Response.StatusCode;
-                string contentDisposition = httpContext.Response.Headers["Content-Disposition"].ToString();
+
+
+                string contentDisposition = httpContext.Response.Headers.ContentDisposition.ToString();
                 CachedResponse response = new CachedResponse(body, contentType, responseCode, contentDisposition);
                 return response;
             }


### PR DESCRIPTION
The suggested filename was not included in the response from the cache since the `content-disposition` header was missing.

This PR fixes this by adding a field that can store the `content-disposition` header in the cache and adding it in rsponses.