### PR TITLE
Fix for note duplication when restoring notes when changing codelist

### DIFF
--- a/PxWeb.UnitTests/Data/PaxiomFixUtilTests.cs
+++ b/PxWeb.UnitTests/Data/PaxiomFixUtilTests.cs
@@ -68,6 +68,33 @@ namespace PxWeb.UnitTests.Data
         }
 
         [TestMethod]
+        public void RestoreNotes_WhenSameNoteExist_DoesNotAddNote()
+        {
+            // Arrange
+            var variable = new Variable("VAR1", "VAR1", PlacementType.Heading, 1);
+            var value = new Value("v1");
+            value.AddNote(new Note("My note", NoteType.Value, true));
+            PaxiomUtil.SetCode(value, "v1");
+            variable.Values.Add(value);
+            value = new Value("v2");
+            PaxiomUtil.SetCode(value, "v2");
+            variable.Values.Add(value);
+            value = new Value("v3");
+            PaxiomUtil.SetCode(value, "v3");
+            variable.Values.Add(value);
+            var notes = new Dictionary<string, Notes>();
+            var list = new Notes();
+            list.Add(new Note("My note", NoteType.Value, true));
+            notes.Add("v1", list);
+
+            // Act
+            PaxiomFixUtil.RestoreNotes(variable, notes);
+
+            // Assert
+            Assert.AreEqual(1, variable.Values[0].Notes.Count);
+        }
+
+        [TestMethod]
         public void RestoreNotes_WhenNotesNotApplicable_ReturnsNotes()
         {
             // Arrange

--- a/PxWeb/Code/Api2/DataSelection/PaxiomFixUtil.cs
+++ b/PxWeb/Code/Api2/DataSelection/PaxiomFixUtil.cs
@@ -31,9 +31,25 @@ namespace PxWeb.Code.Api2.DataSelection
                 {
                     foreach (var note in notes[valueCode])
                     {
-                        value.AddNote(note);
+                        RetoreNote(value, note);
                     }
                 }
+            }
+        }
+
+        private static void RetoreNote(Value value, Note note)
+        {
+            if (value.Notes is null)
+            {
+                value.AddNote(note);
+            }
+            else
+            {
+                if (value.Notes.Any(n => n.Text == note.Text && n.Type == note.Type && n.Mandantory == note.Mandantory))
+                {
+                    return; // Note already exists
+                }
+                value.AddNote(note);
             }
         }
 


### PR DESCRIPTION
Introduce RetoreNote method to prevent duplicate notes. The method checks for existing notes before adding a new one, ensuring that notes with the same text, type, and mandatory status are not duplicated. This enhances the integrity of the notes associated with a Value object.