### PR TITLE
SearchindexController behavior  when tableId is empty-string

### DIFF
--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -53,7 +53,7 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
 
         public ItemSelection ResolveTable(string language, string selection, out bool selectionExists)
         {
-            selectionExists = true;
+            selectionExists = false;
             ItemSelection itemSelection = new ItemSelection();
 
             string lookupTableName = "LookUpTableCache_Table_" + language;
@@ -71,12 +71,10 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                     var itmSel = lookupTable[selection.ToUpper()];
                     itemSelection.Menu = itmSel.Menu;
                     itemSelection.Selection = itmSel.Selection;
-                }
-                else
-                {
-                    selectionExists = false;
+                    selectionExists = true;
                 }
             }
+
             return itemSelection;
         }
     }

--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -64,15 +64,12 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                 _pxCache.Set(lookupTableName, lookupTable);
             }
 
-            if (!string.IsNullOrEmpty(selection))
+            if (!string.IsNullOrEmpty(selection) && lookupTable.ContainsKey(selection.ToUpper()))
             {
-                if (lookupTable.ContainsKey(selection.ToUpper()))
-                {
-                    var itmSel = lookupTable[selection.ToUpper()];
-                    itemSelection.Menu = itmSel.Menu;
-                    itemSelection.Selection = itmSel.Selection;
-                    selectionExists = true;
-                }
+                var itmSel = lookupTable[selection.ToUpper()];
+                itemSelection.Menu = itmSel.Menu;
+                itemSelection.Selection = itmSel.Selection;
+                selectionExists = true;
             }
 
             return itemSelection;

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
@@ -63,15 +63,12 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                 _pxCache.Set(lookupTableName, lookupTable);
             }
 
-            if (!string.IsNullOrEmpty(selection))
+            if (!string.IsNullOrEmpty(selection) && lookupTable.ContainsKey(selection.ToUpper()))
             {
-                if (lookupTable.ContainsKey(selection.ToUpper()))
-                {
-                    var itmSel = lookupTable[selection.ToUpper()];
-                    itemSelection.Menu = itmSel.Menu;
-                    itemSelection.Selection = itmSel.Selection;
-                    selectionExists = true;
-                }
+                var itmSel = lookupTable[selection.ToUpper()];
+                itemSelection.Menu = itmSel.Menu;
+                itemSelection.Selection = itmSel.Selection;
+                selectionExists = true;
             }
             return itemSelection;
         }

--- a/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/ItemSelectionResolverPxFile.cs
@@ -52,7 +52,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
         public ItemSelection ResolveTable(string language, string selection, out bool selectionExists)
         {
 
-            selectionExists = true;
+            selectionExists = false;
             ItemSelection itemSelection = new ItemSelection();
 
             string lookupTableName = "LookUpTableCache_Table_" + language;
@@ -70,10 +70,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                     var itmSel = lookupTable[selection.ToUpper()];
                     itemSelection.Menu = itmSel.Menu;
                     itemSelection.Selection = itmSel.Selection;
-                }
-                else
-                {
-                    selectionExists = false;
+                    selectionExists = true;
                 }
             }
             return itemSelection;

--- a/PxWeb/Controllers/Api2/Admin/SearchindexController.cs
+++ b/PxWeb/Controllers/Api2/Admin/SearchindexController.cs
@@ -135,7 +135,8 @@ namespace PxWeb.Controllers.Api2.Admin
 
         private async Task UpdateFromTableList(List<string> tableList, CancellationToken token)
         {
-            if (tableList.Count == 0)
+
+            if (tableList.Count == 0 || (tableList.Count == 1 && string.IsNullOrEmpty(tableList[0])))
             {
                 string message = "Incoming list with table id's to be updated is empty. Index will not be updated.";
                 _responseState.AddEvent(new Event("Information", message));


### PR DESCRIPTION
SearchindexController chech if list of tableIds just contain an empty string.

ResolveTable returns selectionExists=false when tableId is empty-string