### PR TITLE
Implement efficient cache key hashing mechanism

### DIFF
--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.7" />
     <PackageReference Include="System.IO.Packaging" Version="9.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />


### PR DESCRIPTION
Updated `CacheMiddleware.cs` to use `XxHash128` for generating cache keys based on HTTP request properties. Replaced string concatenation with a 128-bit hash converted to a hexadecimal string. Added `System.IO.Hashing` package to project dependencies in `PxWeb.csproj`.