### PR TITLE
Added useage logging on data retrivials  PXWEB2-769

### DIFF
--- a/PxWeb/Code/Api2/Cache/CachedResponse.cs
+++ b/PxWeb/Code/Api2/Cache/CachedResponse.cs
@@ -7,6 +7,11 @@
         public int ResponseCode { get; set; }
         public string ContentDisposition { get; set; }
 
+        public string? TableId { get; set; }
+        public string? Format { get; set; }
+        public int? MatrixSize { get; set; }
+
+
         public CachedResponse(byte[] content, string? responseType, int responseCode, string contentDisposition)
         {
             this.Content = content;

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -134,6 +134,10 @@ namespace PxWeb.Controllers.Api2
             Response.ContentType = serializationInfo.ContentType;
             Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
             serializationInfo.Serializer.Serialize(model, Response.Body);
+
+            HttpContext.Items["PX_TableId"] = id;
+            HttpContext.Items["PX_Format"] = outputFormatStr;
+            HttpContext.Items["PX_Matrix_Size"] = model.Data.MatrixSize;
             return Ok();
         }
 

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -266,6 +266,9 @@ namespace PxWeb.Controllers.Api2
             Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
             serializationInfo.Serializer.Serialize(model, Response.Body);
 
+            HttpContext.Items["PX_TableId"] = id;
+            HttpContext.Items["PX_Format"] = outputFormatStr;
+            HttpContext.Items["PX_Matrix_Size"] = model.Data.MatrixSize;
             return Ok();
         }
 

--- a/PxWeb/Middleware/CacheMiddleware.cs
+++ b/PxWeb/Middleware/CacheMiddleware.cs
@@ -45,6 +45,23 @@ namespace PxWeb.Middleware
 
                 string contentDisposition = httpContext.Response.Headers.ContentDisposition.ToString();
                 CachedResponse response = new CachedResponse(body, contentType, responseCode, contentDisposition);
+
+                if (httpContext.Items.TryGetValue("PX_TableId", out var tableId))
+                {
+                    response.TableId = tableId as string;
+                }
+
+                if (httpContext.Items.TryGetValue("PX_Format", out var format))
+                {
+                    response.Format = format as string;
+                }
+
+                if (httpContext.Items.TryGetValue("PX_Matrix_Size", out var matrixSize))
+                {
+                    response.MatrixSize = matrixSize as int?;
+                }
+
+
                 return response;
             }
         }
@@ -100,6 +117,13 @@ namespace PxWeb.Middleware
             else
             {
                 response = cached;
+            }
+
+            if (response.TableId is not null && _logger.IsEnabled(LogLevel.Debug))
+            {
+                httpContext.Items["PX_TableId"] = response.TableId;
+                httpContext.Items["PX_Format"] = response.Format;
+                httpContext.Items["PX_Matrix_Size"] = response.MatrixSize;
             }
 
             httpContext.Response.ContentType = response.ContentType;

--- a/PxWeb/Middleware/UsageLogMiddleware.cs
+++ b/PxWeb/Middleware/UsageLogMiddleware.cs
@@ -1,0 +1,64 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+using PxWeb.Code.Api2.Cache;
+
+namespace PxWeb.Middleware
+{
+    public class UsageLogMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<UsageLogMiddleware> _logger;
+
+        public UsageLogMiddleware(RequestDelegate next, ILogger<UsageLogMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task Invoke(HttpContext context, IPxCache cache)
+        {
+            await _next(context);
+            if (context.Response.StatusCode == 200)
+            {
+                if (context.Items.TryGetValue("PX_TableId", out var tableId) &&
+                    context.Items.TryGetValue("PX_Format", out var format) &&
+                    context.Items.TryGetValue("PX_Matrix_Size", out var size))
+                {
+                    if (tableId is not null &&
+                        format is not null &&
+                        size is not null)
+                    {
+                        _logger.LogIndexingStarted((string)tableId, (string)format, (int)size);
+                    }
+
+
+                }
+            }
+        }
+    }
+
+    public static class UseUsageLogMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseUsageLogMiddleware(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<UsageLogMiddleware>();
+        }
+    }
+
+    internal static partial class UsageLogMessages
+    {
+        [LoggerMessage(
+            Message = "Fetch data for tableId={tableId}, format={format}, size={size}",
+            Level = LogLevel.Information,
+            SkipEnabledCheck = false)]
+        internal static partial void LogIndexingStarted(
+            this ILogger logger,
+            string tableId,
+            string format,
+            int size);
+    }
+}

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -204,6 +204,7 @@ namespace PxWeb
 
             app.UseWhen(context => !(context.Request.Path.StartsWithSegments(pxApiConfiguration.RoutePrefix + "/admin") || context.Request.Path.StartsWithSegments("/admin")), appBuilder =>
             {
+                appBuilder.UseUsageLogMiddleware();
                 appBuilder.UseCacheMiddleware();
             });
 

--- a/PxWeb/log4net.config
+++ b/PxWeb/log4net.config
@@ -23,17 +23,34 @@
       <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
     </layout>
   </appender>
+
+  <appender name="UsageAppender" type="log4net.Appender.RollingFileAppender">
+    <file value="logs/usage.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <datePattern value="yyyyMMdd" />
+    <maxSizeRollBackups value="20" />
+    <maximumFileSize value="4MB" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+    </layout>
+  </appender>
+  
   <root>
     <level value="ALL"/>
     <appender-ref ref="Console" />
   </root>
+  <logger name="PxWeb.Middleware.UsageLogMiddleware">
+    <level value="INFO"/>
+    <appender-ref ref="UsageAppender" />
+  </logger>
   <logger name="PCAxis.Paxiom">
-    <level value="INFO" />
+    <level value="WARN" />
   </logger>
   <logger name="PCAxis.Sql">
-    <level value="INFO" />
+    <level value="WARN" />
   </logger>
   <logger name="PCAxis.PlugIn.Sql">
-    <level value="INFO" />
+    <level value="WARN" />
   </logger>
 </log4net>


### PR DESCRIPTION
Add logging and caching enhancements to middleware

Updated `CachedResponse` to include `TableId`, `Format`, and `MatrixSize`. Modified controllers to store these values in `HttpContext.Items`. Enhanced `CacheMiddleware` to retrieve and log these properties. Introduced `UsageLogMiddleware` for logging indexing processes. Registered the new middleware in `Program.cs` for request processing.