### PR TITLE
Add pastDays to the `TablesResponse` in the links if specified PXWEB2-792

### DIFF
--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -185,7 +185,7 @@ namespace PxWeb.Controllers.Api2
                 return NotFound(ProblemUtility.OutOfRange());
             }
 
-            return Ok(_tablesResponseMapper.Map(searchResultContainer, lang, query));
+            return Ok(_tablesResponseMapper.Map(searchResultContainer, lang, query, pastDays));
 
         }
 

--- a/PxWeb/Mappers/ILinkCreator.cs
+++ b/PxWeb/Mappers/ILinkCreator.cs
@@ -6,7 +6,7 @@ namespace PxWeb.Mappers
 {
     public interface ILinkCreator
     {
-        Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int pagesize, int pageNumber, bool showLangParam = true);
+        Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int? pastDays, int pagesize, int pageNumber, bool showLangParam = true);
         Link GetTableLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetTableMetadataJsonLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetTableDataLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);

--- a/PxWeb/Mappers/ITablesResponseMapper.cs
+++ b/PxWeb/Mappers/ITablesResponseMapper.cs
@@ -6,6 +6,6 @@ namespace PxWeb.Mappers
 {
     public interface ITablesResponseMapper
     {
-        TablesResponse Map(SearchResultContainer searchResultContainer, string lang, string? query);
+        TablesResponse Map(SearchResultContainer searchResultContainer, string lang, string? query, int? pastDays);
     }
 }

--- a/PxWeb/Mappers/LinkCreator.cs
+++ b/PxWeb/Mappers/LinkCreator.cs
@@ -28,12 +28,12 @@ namespace PxWeb.Mappers
             _urlPrefix = configOptions.Value.BaseURL + configOptions.Value.RoutePrefix;
             _defaultDataFormat = configOptions.Value.DefaultOutputFormat;
         }
-        public Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int pagesize, int pageNumber, bool showLangParam = true)
+        public Link GetTablesLink(LinkRelationEnum relation, string language, string? query, int? pastDays, int pagesize, int pageNumber, bool showLangParam = true)
         {
             var link = new Link();
             link.Rel = relation.ToString();
             link.Hreflang = language;
-            link.Href = CreatePageURL($"tables/", language, showLangParam, query, pagesize, pageNumber);
+            link.Href = CreatePageURL($"tables/", language, showLangParam, query, pastDays, pagesize, pageNumber);
 
             return link;
         }
@@ -127,7 +127,7 @@ namespace PxWeb.Mappers
 
             return sb.ToString();
         }
-        private string CreatePageURL(string endpointUrl, string language, bool showLangParam, string? query, int pagesize, int pageNumber)
+        private string CreatePageURL(string endpointUrl, string language, bool showLangParam, string? query, int? pastDays, int pagesize, int pageNumber)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -161,6 +161,11 @@ namespace PxWeb.Mappers
             }
 
             sb.Append("&pageNumber=" + pageNumber);
+
+            if (pastDays is not null)
+            {
+                sb.Append("&pastDays=" + pastDays.Value);
+            }
 
             return sb.ToString();
         }

--- a/PxWeb/Mappers/TablesResponseMapper.cs
+++ b/PxWeb/Mappers/TablesResponseMapper.cs
@@ -19,7 +19,7 @@ namespace PxWeb.Mappers
             _configOptions = configOptions.Value;
         }
 
-        public TablesResponse Map(SearchResultContainer searchResultContainer, string lang, string? query)
+        public TablesResponse Map(SearchResultContainer searchResultContainer, string lang, string? query, int? pastDays)
         {
             var tablesResponse = new TablesResponse();
             var linkPageList = new List<Link>();
@@ -28,22 +28,24 @@ namespace PxWeb.Mappers
             var totalElements = searchResultContainer.totalElements;
             var totalPages = searchResultContainer.totalPages;
 
+
+
             if (pageNumber < totalPages)
             {
                 // Links to next page 
-                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.next, lang, query, pageSize, pageNumber + 1, true));
+                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.next, lang, query, pastDays, pageSize, pageNumber + 1, true));
             }
 
             if (pageNumber <= totalPages && pageNumber != 1)
             {
                 // Links to previous page 
-                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.previous, lang, query, pageSize, pageNumber - 1, true));
+                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.previous, lang, query, pastDays, pageSize, pageNumber - 1, true));
             }
 
             if (totalPages > 1)
             {
                 // Links to last page 
-                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.last, lang, query, pageSize, totalPages, true));
+                linkPageList.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.last, lang, query, pastDays, pageSize, totalPages, true));
             }
 
             PageInfo page = new PageInfo
@@ -100,7 +102,7 @@ namespace PxWeb.Mappers
             var linkListTableResponse = new List<Link>();
 
             // Links to tablesResponse
-            linkListTableResponse.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.self, lang, query, page.PageSize, page.PageNumber, true));
+            linkListTableResponse.Add(_linkCreator.GetTablesLink(LinkCreator.LinkRelationEnum.self, lang, query, pastDays, page.PageSize, page.PageNumber, true));
 
             tablesResponse.Links = linkListTableResponse;
 


### PR DESCRIPTION
Add pastDays parameter to link and response mapping

This commit introduces a new `pastDays` parameter to several methods within the `PxWeb.Mappers` namespace. The `GetTablesLink` method in both `ILinkCreator` and `LinkCreator`, as well as the `Map` method in `ITablesResponseMapper` and `TablesResponseMapper`, have been updated to accommodate this parameter. These changes enhance the functionality of link generation and table response mapping, allowing for more flexible querying based on time constraints.