### PR TITLE
Enhance SavedQueryApiController and TableApiController with saved query parameter

### DIFF
--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -6,31 +6,43 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using Px.Abstractions.Interfaces;
+
 using PxWeb.Api2.Server.Models;
 using PxWeb.Code;
 using PxWeb.Code.Api2;
+using PxWeb.Code.Api2.DataSelection;
 using PxWeb.Code.Api2.SavedQueryBackend;
 using PxWeb.Code.Api2.Serialization;
 using PxWeb.Helper.Api2;
+using PxWeb.Mappers;
 
 namespace PxWeb.Controllers.Api2
 {
     [ApiController]
     public class SavedQueryApiController : PxWeb.Api2.Server.Controllers.SavedQueriesApiController
     {
+        private readonly ISelectionResponseMapper _selectionResponseMapper;
+        private readonly IDataSource _dataSource;
+        private readonly ILanguageHelper _languageHelper;
         private readonly PxApiConfigurationOptions _configOptions;
         private readonly ISavedQueryBackendProxy _savedQueryBackendProxy;
         private readonly ISerializeManager _serializeManager;
         private readonly IDataWorkflow _dataWorkflow;
         private readonly ILogger<SavedQueryApiController> _logger;
+        private readonly ISelectionHandler _selectionHandler;
 
-        public SavedQueryApiController(IDataWorkflow dataWorkflow, ISavedQueryBackendProxy savedQueryStorageBackend, ISerializeManager serializeManager, IOptions<PxApiConfigurationOptions> configOptions, ILogger<SavedQueryApiController> logger)
+        public SavedQueryApiController(IDataWorkflow dataWorkflow, ISavedQueryBackendProxy savedQueryStorageBackend, ISerializeManager serializeManager, IOptions<PxApiConfigurationOptions> configOptions, ILogger<SavedQueryApiController> logger, IDataSource dataSource, ILanguageHelper languageHelper, ISelectionResponseMapper selectionResponseMapper, ISelectionHandler selectionHandler)
         {
             _dataWorkflow = dataWorkflow;
             _savedQueryBackendProxy = savedQueryStorageBackend;
             _serializeManager = serializeManager;
             _configOptions = configOptions.Value;
             _logger = logger;
+            _dataSource = dataSource;
+            _languageHelper = languageHelper;
+            _selectionResponseMapper = selectionResponseMapper;
+            _selectionHandler = selectionHandler;
         }
 
         public override IActionResult CreateSaveQuery([FromBody] SavedQuery? savedQuery)
@@ -135,6 +147,41 @@ namespace PxWeb.Controllers.Api2
             Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
             serializationInfo.Serializer.Serialize(model, Response.Body);
             return Ok();
+        }
+
+        public override IActionResult GetSavedQuerySelection([FromRoute(Name = "id")][Required] string id, [FromQuery(Name = "lang")] string? lang)
+        {
+            lang = _languageHelper.HandleLanguage(lang);
+
+            VariablesSelection selection;
+
+            var savedQuery = _savedQueryBackendProxy.Load(id);
+            if (savedQuery is null)
+            {
+                _logger.LogNoSavedQueryWithGivenId();
+                return NotFound(ProblemUtility.NonExistentSavedQuery());
+            }
+
+            selection = savedQuery.Selection;
+
+            var builder = _dataSource.CreateBuilder(savedQuery.TableId, lang);
+            if (builder == null)
+            {
+                _logger.LogNoTableWithGivenId();
+                return NotFound(ProblemUtility.NonExistentTable());
+            }
+
+            builder.BuildForSelection();
+
+            if (!_selectionHandler.ExpandAndVerfiySelections(selection, builder, out Problem? problem))
+            {
+                _logger.LogParameterError();
+                return BadRequest(problem);
+            }
+
+            //Map selection to SelectionResponse
+            SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, id, lang);
+            return Ok(selectionResponse);
         }
 
     }

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.8" />
     <PackageReference Include="PCAxis.Serializers" Version="1.9.0" />
     <PackageReference Include="PcAxis.Sql" Version="1.4.3" />
-    <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.18" />
+    <PackageReference Include="PxWeb.Api2.Server" Version="2.0.0-beta.19" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.1" />


### PR DESCRIPTION
Updated SavedQueryApiController to include new dependencies for improved handling of saved queries, and added GetSavedQuerySelection method. Modified TableApiController's GetMetadataById to accept savedQueryId for applying saved queries. Updated PxWeb.csproj to reference a newer version of the PxWeb.Api2.Server package.