### PR TITLE
Fixed so that self link for /savedqueries/2202/selection

### DIFF
--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -190,7 +190,7 @@ namespace PxWeb.Controllers.Api2
             }
 
             //Map selection to SelectionResponse
-            SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, id, lang);
+            SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, id, lang, true);
             return Ok(selectionResponse);
         }
 

--- a/PxWeb/Controllers/Api2/TableApiController.cs
+++ b/PxWeb/Controllers/Api2/TableApiController.cs
@@ -387,7 +387,7 @@ namespace PxWeb.Controllers.Api2
             }
 
             //Map selection to SelectionResponse
-            SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, id, lang);
+            SelectionResponse selectionResponse = _selectionResponseMapper.Map(selection, id, lang, false);
             return Ok(selectionResponse);
         }
 

--- a/PxWeb/Mappers/ILinkCreator.cs
+++ b/PxWeb/Mappers/ILinkCreator.cs
@@ -13,5 +13,6 @@ namespace PxWeb.Mappers
         Link GetCodelistLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetFolderLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
         Link GetDefaultSelectionLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
+        Link GetSavedQuerySelectionLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true);
     }
 }

--- a/PxWeb/Mappers/ISelectionResponseMapper.cs
+++ b/PxWeb/Mappers/ISelectionResponseMapper.cs
@@ -4,6 +4,6 @@ namespace PxWeb.Mappers
 {
     public interface ISelectionResponseMapper
     {
-        SelectionResponse Map(VariablesSelection selections, string tableId, string lang);
+        SelectionResponse Map(VariablesSelection selections, string tableId, string lang, bool fromSavedQuery);
     }
 }

--- a/PxWeb/Mappers/LinkCreator.cs
+++ b/PxWeb/Mappers/LinkCreator.cs
@@ -88,6 +88,17 @@ namespace PxWeb.Mappers
             return link;
         }
 
+        public Link GetSavedQuerySelectionLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true)
+        {
+            var link = new Link();
+            link.Rel = relation.ToString();
+            link.Hreflang = language;
+            link.Href = CreateURL($"savedqueries/{id}/selection", language, showLangParam, null);
+
+            return link;
+        }
+
+
         public Link GetFolderLink(LinkRelationEnum relation, string id, string language, bool showLangParam = true)
         {
             var link = new Link();

--- a/PxWeb/Mappers/SelectionResponseMapper.cs
+++ b/PxWeb/Mappers/SelectionResponseMapper.cs
@@ -12,7 +12,7 @@ namespace PxWeb.Mappers
             _linkCreator = linkCreator;
         }
 
-        public SelectionResponse Map(VariablesSelection selections, string tableId, string lang)
+        public SelectionResponse Map(VariablesSelection selections, string tableOrSavedQueryId, string lang, bool fromSavedQuery)
         {
             var response = new SelectionResponse();
             response.Selection = selections.Selection;
@@ -21,8 +21,14 @@ namespace PxWeb.Mappers
 
             response.Links = new List<Link>();
 
-            response.Links.Add(_linkCreator.GetDefaultSelectionLink(LinkCreator.LinkRelationEnum.self, tableId, lang, true));
-
+            if (fromSavedQuery)
+            {
+                response.Links.Add(_linkCreator.GetSavedQuerySelectionLink(LinkCreator.LinkRelationEnum.self, tableOrSavedQueryId, lang, true));
+            }
+            else
+            {
+                response.Links.Add(_linkCreator.GetDefaultSelectionLink(LinkCreator.LinkRelationEnum.self, tableOrSavedQueryId, lang, true));
+            }
             return response;
         }
 


### PR DESCRIPTION
The bug: /savedqueries/2202/selection  
returned  "links":[{"rel":"self","hreflang":"no","href":"https://data.ssb.no/api/pxwebapi/v2-beta/tables/2202/defaultselection?lang=no"}],
 
Now it returns /savedqueries/2202/selection   