### PR TITLE
changes MaintenanceHealthCheck fail to Unhealty

### DIFF
--- a/PxWeb.UnitTests/Helpers/HealthCheckTests.cs
+++ b/PxWeb.UnitTests/Helpers/HealthCheckTests.cs
@@ -33,7 +33,7 @@ namespace PxWeb.UnitTests.Helpers
 
 
         [TestMethod]
-        public void When_MaintenanceFile_Then_HealthCheckIsDegraded()
+        public void When_MaintenanceFile_Then_HealthCheckIsUnhealthy()
         {
             var host = new Mock<IPxHost>();
             var tempPath = Path.GetTempPath();
@@ -54,7 +54,7 @@ namespace PxWeb.UnitTests.Helpers
             var cancellationToken = CancellationToken.None;
             var result = healthCheck.CheckHealthAsync(context, cancellationToken).Result;
             // Assert
-            Assert.AreEqual(HealthStatus.Degraded, result.Status);
+            Assert.AreEqual(HealthStatus.Unhealthy, result.Status);
 
             File.Delete(maintenanceFilePath);
         }

--- a/PxWeb/Code/MaintenanceHealthCheck.cs
+++ b/PxWeb/Code/MaintenanceHealthCheck.cs
@@ -22,7 +22,7 @@ namespace PxWeb.Code
         {
             if (File.Exists(_maintenanceFilePath))
             {
-                return Task.FromResult(HealthCheckResult.Degraded("Maintenance mode is active (.maintenance file found)."));
+                return Task.FromResult(HealthCheckResult.Unhealthy("Maintenance mode is active (.maintenance file found)."));
             }
 
             return Task.FromResult(HealthCheckResult.Healthy("No maintenance file found."));


### PR DESCRIPTION
Before this, the presence of a .maintenance file leads to HealthCheckResult.Degraded with status 200
Now it yeilds Unhealthy (status 503)
Which is not perfect, but I think the status code should be 503. 
  
  