### PR TITLE
Fix for paths removed on partial update of the search index

### DIFF
--- a/Px.Search.Lucene/LuceneIndex.cs
+++ b/Px.Search.Lucene/LuceneIndex.cs
@@ -141,6 +141,7 @@ namespace Px.Search.Lucene
                 var paths = oldDoc.GetBinaryValue(SearchConstants.SEARCH_FIELD_PATHS);
                 if (paths is not null)
                 {
+                    doc.RemoveField(SearchConstants.SEARCH_FIELD_PATHS);
                     doc.Add(new StoredField(SearchConstants.SEARCH_FIELD_PATHS, paths));
                 }
             }


### PR DESCRIPTION
Refactor the processing of the SEARCH_FIELD_PATHS field to remove the existing field from the document when updating it with new binary values from oldDoc. This ensures the field is correctly refreshed with the latest paths.