### PR TITLE
Added discontinued mapping

### DIFF
--- a/Px.Search/Indexer.cs
+++ b/Px.Search/Indexer.cs
@@ -258,7 +258,7 @@
             tbl.Description = tblLink.Description;
             tbl.SortCode = tblLink.SortCode;
             tbl.Updated = tblLink.LastUpdated;
-            tbl.Discontinued = null; // TODO: Implement later
+            tbl.Discontinued = tblLink.Status == TableStatus.Discontinued ? true : null;
             tbl.SubjectCode = meta.SubjectCode ?? string.Empty;
 
             return tbl;

--- a/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/PxFileDataSource.cs
@@ -203,7 +203,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
         public Item? LoadDatabaseStructure(string language)
         {
             var filePath = System.IO.Path.Combine(_hostingEnvironment.RootPath, "Database", "Menu.xml");
-            var menu = new XmlMenu(filePath, language);
+            var menu = new XmlMenu(XDocument.Load(filePath), language, m => m.Restriction = x => true);
 
             // Fix selection for subitems - we only want the last part...
             if (menu.CurrentItem is PxMenuItem menuItem)

--- a/PxWeb/Code/PxDatabase/Builders/MenuBuilder.cs
+++ b/PxWeb/Code/PxDatabase/Builders/MenuBuilder.cs
@@ -349,9 +349,17 @@ namespace PXWeb.Database
             DateTime? initPublished = null;
             DateTime? initLastUpdated = null;
 
+
+            var status = TableStatus.AccessibleToAll;
+
+            if (meta.ExtendedProperties.TryGetValue("DISCONTINUED", out var discontinued) && discontinued.Equals("YES", StringComparison.OrdinalIgnoreCase))
+            {
+                status = TableStatus.Discontinued;
+            }
+
             TableLink tbl = new TableLink(!string.IsNullOrEmpty(meta.Description) ? meta.Description : meta.Title,
                 meta.Matrix, _sortOrder(meta, path), cid.Menu, cid.Selection.Replace("\\", "/"), meta.Description ?? "", LinkType.PX,
-                TableStatus.AccessibleToAll, initPublished, initLastUpdated, meta.GetFirstTimeValue(), meta.GetLastTimeValue(), meta.Matrix ?? "", PresCategory.Official);
+                status, initPublished, initLastUpdated, meta.GetFirstTimeValue(), meta.GetLastTimeValue(), meta.Matrix ?? "", PresCategory.Official);
 
             int cellCount = 1;
             for (int i = 0; i < meta.Variables.Count; i++)


### PR DESCRIPTION
Refactor discontinued status handling and menu loading

- Updated `tbl.Discontinued` in `Indexer.cs` to derive its value from `tblLink.Status` instead of being set to null.
- Changed `XmlMenu` instantiation in `PxFileDataSource.cs` to load XML using `XDocument.Load`, enhancing item selection flexibility.
- Introduced a `status` variable in `MenuBuilder.cs` to manage table status based on the "DISCONTINUED" property in `meta.ExtendedProperties`.