### PR TITLE
Added missing config sections in PxWeb config for dock installs

### DIFF
--- a/docker/pxweb2/public/config/config.js
+++ b/docker/pxweb2/public/config/config.js
@@ -1,11 +1,24 @@
 window.PxWeb2Config = {
   language: {
-    supportedLanguages: [{ shorthand: "en", languageName: "English" }],
-    defaultLanguage: "en",
-    fallbackLanguage: "en",
+    supportedLanguages: [
+      { shorthand: 'en', languageName: 'English' },
+    ],
+    defaultLanguage: 'en',
+    fallbackLanguage: 'en',
     showDefaultLanguageInPath: true,
   },
-  apiUrl: "//localhost:8081/api/v2",
+  baseApplicationPath: '/',
+  apiUrl: '//localhost:8081/api/v2',
   maxDataCells: 150000,
-  specialCharacters: [".", "..", ":", "-", "...", "*"],
+  specialCharacters: ['.', '..', ':', '-', '...', '*'],
+  variableFilterExclusionList: {
+    en: [
+      'observations',
+      'year',
+      'quarter',
+      'month',
+      'every other year',
+      'every fifth year',
+    ]
+  },
 };


### PR DESCRIPTION
Updated the `config.js` example file for PxWeb that is used for the Docker installs. Now it included missing section that it required by PxWeb.