### PR TITLE
fix: Changed the default search operation to `AND` PXWEB-952

### DIFF
--- a/Px.Search.Lucene/LuceneSearcher.cs
+++ b/Px.Search.Lucene/LuceneSearcher.cs
@@ -7,7 +7,7 @@ namespace Px.Search.Lucene
     public class LuceneSearcher : ISearcher
     {
         private readonly IndexSearcher _indexSearcher;
-        private static readonly Operator _defaultOperator = Operator.OR;
+        private static readonly Operator _defaultOperator = Operator.AND;
         private readonly Analyzer _analyzer;
 
         /// <summary>


### PR DESCRIPTION
Changed the default search operation from `OR` to `AND`