### PR TITLE
Fix missing ModelBinder for outputFormatParams in GetTableDataByPost

### DIFF
--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -214,7 +214,7 @@ namespace PxWeb.Controllers.Api2
             [FromRoute(Name = "id"), Required] string id,
             [FromQuery(Name = "lang")] string? lang,
             [FromQuery(Name = "outputFormat")] OutputFormatType? outputFormat,
-            [FromQuery(Name = "outputFormatParams")] List<OutputFormatParamType>? outputFormatParams,
+            [FromQuery(Name = "outputFormatParams"), ModelBinder(typeof(OutputFormatParamsModelBinder))] List<OutputFormatParamType>? outputFormatParams,
             [FromBody] VariablesSelection? variablesSelection)
         {
             return GetData(id, lang, variablesSelection, outputFormat, outputFormatParams is null ? new List<OutputFormatParamType>() : outputFormatParams);


### PR DESCRIPTION
POST requests to the data endpoint return 400 when multiple outputFormatParams are specified in the query string (e.g. outputFormatParams=UseTexts,IncludeTitle), while the same query works fine with GET.

The cause is that GetTableDataByPost is missing the ModelBinder(typeof(OutputFormatParamsModelBinder)) attribute on the outputFormatParams parameter, which GetTableData (GET) has. Without it, ASP.NET Core falls back to default binding, which cannot handle comma-separated enum values.

Fix: add the missing attribute, consistent with the GET endpoint.