### PR TITLE
chore: update .NET SDK and ASP.NET base images to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Learn about building .NET container images:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.418-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.419-alpine3.23 AS build
 ARG TARGETARCH
 WORKDIR /source
 
@@ -15,7 +15,7 @@ RUN \
 # Enable globalization and time zones:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0.24-alpine3.22
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.25-alpine3.23
 EXPOSE 8080
 
 ENV \


### PR DESCRIPTION
Dependabot can't handle the alpine version bump, therefore we have to bump manually when alpine changes.  `aspnet:8.0.25-alpine3.23` should close a security issue