### PR TITLE
build: add cooldown configuration for all package ecosystems in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,26 @@ updates:
         applies-to: version-updates
         update-types:
           - "minor"
+    cooldown:
+      default-days: 9
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 9
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 9
 
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 9


### PR DESCRIPTION
Used the same cooldown setting as PxWeb2 repo