### PR TITLE
fix:Made sure that the key is upper case in ResolveFolder

### DIFF
--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -109,14 +109,14 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
                 }
                 else
                 {
-                    filter[selection.Menu] = new List<ItemSelection>() { selection };
+                    filter[selection.Menu.ToUpper()] = new List<ItemSelection>() { selection };
                 }
             }
 
-            if (filter.ContainsKey(rootItem))
+            if (filter.ContainsKey(rootItem.ToUpper()))
             {
-                newLookup.Add(rootItem, lookupTable[rootItem]);
-                AddRecursive(rootItem, newLookup, filter);
+                newLookup.Add(rootItem.ToUpper(), lookupTable[rootItem]);
+                AddRecursive(rootItem.ToUpper(), newLookup, filter);
             }
 
             return newLookup;
@@ -133,8 +133,8 @@ namespace PxWeb.Code.Api2.DataSource.Cnmm
             {
                 foreach (var selection in selections)
                 {
-                    result.Add(selection.Selection, selection);
-                    AddRecursive(selection.Selection, result, lookup);
+                    result.Add(selection.Selection.ToUpper(), selection);
+                    AddRecursive(selection.Selection.ToUpper(), result, lookup);
                 }
             }
         }


### PR DESCRIPTION
When specifying a root node the key lookup table for finding folders was not upper cased. This caused problem when trying to resolve the folder id. This PR make sure that the key is in upper case.