### PR TITLE
Fix: handle null GetAllLanguages() and preserve ContentInfo for single-language PX files

### DIFF
--- a/PxWeb.UnitTests/DataSource/PxFileBuilder2Test.cs
+++ b/PxWeb.UnitTests/DataSource/PxFileBuilder2Test.cs
@@ -1,0 +1,138 @@
+namespace PxWeb.UnitTests.DataSource
+{
+    [TestClass]
+    public class PxFileBuilder2Test
+    {
+        internal static string GetFullPathToFile(string pathRelativeUnitTestingFile)
+        {
+            string folderProjectLevel = GetPathToPxWebProject();
+            string final = System.IO.Path.Combine(folderProjectLevel, pathRelativeUnitTestingFile);
+            return final;
+        }
+
+        private static string GetPathToPxWebProject()
+        {
+            string pathAssembly = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            string directoryName = System.IO.Path.GetDirectoryName(pathAssembly) ?? throw new System.Exception("GetDirectoryName(pathAssembly) is null for:" + pathAssembly);
+            string folderAssembly = directoryName.Replace("\\", "/");
+            if (!folderAssembly.EndsWith('/')) folderAssembly = folderAssembly + "/";
+            string folderProjectLevel = System.IO.Path.GetFullPath(folderAssembly + "../../../../");
+            return folderProjectLevel;
+        }
+
+        private PxFileDataSource GetDataSource()
+        {
+            var testFactory = new TestFactory();
+            var memorymock = new Mock<IPxCache>();
+            var configMock = new Mock<IPxApiConfigurationService>();
+            var configServiceMock = new Mock<IPxFileConfigurationService>();
+            var hostingEnvironmentMock = new Mock<IPxHost>();
+            var loggerMock = new Mock<ILogger<TablePathResolverPxFile>>();
+            var codelistMapperMock = new Mock<ICodelistMapper>();
+            var itemLoggerMock = new Mock<ILogger<ItemSelectorResolverPxFactory>>();
+
+            var config = testFactory.GetPxApiConfiguration();
+            configMock.Setup(x => x.GetConfiguration()).Returns(config);
+
+            var pcAxisFactory = new ItemSelectorResolverPxFactory(configServiceMock.Object, hostingEnvironmentMock.Object, itemLoggerMock.Object);
+
+            var wwwrootPath = GetFullPathToFile(@"PxWeb/wwwroot/");
+            hostingEnvironmentMock.Setup(m => m.RootPath).Returns(wwwrootPath);
+
+            var resolver = new ItemSelectionResolverPxFile(memorymock.Object, pcAxisFactory, configMock.Object);
+            var tablePathResolver = new TablePathResolverPxFile(memorymock.Object, hostingEnvironmentMock.Object, configMock.Object, loggerMock.Object);
+
+            return new PxFileDataSource(configServiceMock.Object, resolver, tablePathResolver, hostingEnvironmentMock.Object, codelistMapperMock.Object);
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_DoesNotThrow()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act & assert
+            builder.BuildForSelection(); // must not throw
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_ReturnsTrue()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act
+            var result = builder.BuildForSelection();
+
+            //assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_CreatesContentVariable()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act
+            builder.BuildForSelection();
+
+            //assert
+            Assert.IsNotNull(builder.Model.Meta.ContentVariable);
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_ContentVariableIsMarkedAsContentVariable()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act
+            builder.BuildForSelection();
+
+            //assert
+            Assert.IsTrue(builder.Model.Meta.ContentVariable.IsContentVariable);
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_ContentInfoNotNulledOnMeta()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act
+            builder.BuildForSelection();
+
+            //assert
+            Assert.IsNotNull(builder.Model.Meta.ContentInfo,
+                "meta.ContentInfo must not be null after BuildForSelection — serializers such as Xlsx2Serializer depend on it.");
+        }
+
+        [TestMethod]
+        public void BuildForSelection_SingleLanguagePxFile_ContentInfoCopiedToContentVariableValue()
+        {
+            //arrange
+            var dataSource = GetDataSource();
+            var builder = dataSource.CreateBuilder("TAB003", "en");
+            Assert.IsNotNull(builder);
+
+            //act
+            builder.BuildForSelection();
+
+            //assert
+            var value = builder.Model.Meta.ContentVariable.Values[0];
+            Assert.IsNotNull(value.ContentInfo,
+                "ContentInfo should be copied from meta to the content variable value.");
+        }
+    }
+}

--- a/PxWeb/Code/Api2/DataSource/PxFile/PxFileBuilder2.cs
+++ b/PxWeb/Code/Api2/DataSource/PxFile/PxFileBuilder2.cs
@@ -29,7 +29,6 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                     PaxiomUtil.SetCode(value, "content");
                     // Move the contentInfo from tablelevel to the content value
                     value.ContentInfo = meta.ContentInfo;
-                    meta.ContentInfo = null;
                     contentVariable.Values.Add(value);
 
                     // Insert the content variable as the first variable in the stub
@@ -40,7 +39,7 @@ namespace PxWeb.Code.Api2.DataSource.PxFile
                     // Add text and ContentInfo for all languages
                     var languages = meta.GetAllLanguages();
                     var currentLanguage = meta.CurrentLanguage;
-                    for (int i = 0; i < languages.Length; i++)
+                    for (int i = 0; i < languages?.Length; i++)
                     {
                         var lang = languages[i];
 


### PR DESCRIPTION
## Problem

`BuildForSelection` threw `NullReferenceException` when requesting xlsx (or other non-JSON formats) for single-language PX files — files without a `LANGUAGES` keyword. Two bugs caused this:

1. `meta.GetAllLanguages()` returns `null` for single-language PX files, but the code iterated over it without a null check
2. `meta.ContentInfo` was set to `null` after being copied to the content variable value, causing `Xlsx2Serializer` to crash when reading it from the table level

## Fix

- Added null guard: `for (int i = 0; i < languages?.Length; i++)`
- Removed the `meta.ContentInfo = null;` line

## Tests

Added `PxFileBuilder2Test.cs` covering `BuildForSelection` for single-language PX files, verifying it does not throw, creates the content variable, and preserves `ContentInfo` on both the meta and the value.