### PR TITLE
feat: Adds request timeout handling for table data endpoints

### DIFF
--- a/PxWeb/Code/Api2/DataWorkflow.cs
+++ b/PxWeb/Code/Api2/DataWorkflow.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 
 using PCAxis.Paxiom;
 using PCAxis.Paxiom.Operations;
@@ -25,7 +26,7 @@ namespace PxWeb.Code.Api2
             _defaultSelectionAlgorithm = defaultSelectionAlgorithm;
             _placementHandler = placementHandler;
         }
-        public PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem)
+        public PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem, CancellationToken token)
         {
             //If no selection is made, return a problem and exit early
             if (variablesSelection is null)
@@ -42,11 +43,15 @@ namespace PxWeb.Code.Api2
                 problem = ProblemUtility.NonExistentTable();
                 return null;
             }
+
+            token.ThrowIfCancellationRequested();
+
             builder.BuildForSelection();
-            return Run(variablesSelection, builder, out problem);
+
+            return Run(variablesSelection, builder, out problem, token);
         }
 
-        public PXModel? Run(string tableId, string language, out Problem? problem)
+        public PXModel? Run(string tableId, string language, out Problem? problem, CancellationToken token)
         {
             var builder = _dataSource.CreateBuilder(tableId, language);
             if (builder == null)
@@ -55,7 +60,11 @@ namespace PxWeb.Code.Api2
                 return null;
             }
 
+            token.ThrowIfCancellationRequested();
+
             builder.BuildForSelection();
+
+            token.ThrowIfCancellationRequested();
 
             var variablesSelection = _defaultSelectionAlgorithm.GetDefaultSelection(builder);
             //If no selection is made, return a problem and exit early
@@ -66,11 +75,13 @@ namespace PxWeb.Code.Api2
 
             }
 
+
+
             // Create a builder for the table and read in the table metadata
-            return Run(variablesSelection, builder, out problem);
+            return Run(variablesSelection, builder, out problem, token);
         }
 
-        private PXModel? Run(VariablesSelection variablesSelection, IPXModelBuilder? builder, out Problem? problem)
+        private PXModel? Run(VariablesSelection variablesSelection, IPXModelBuilder? builder, out Problem? problem, CancellationToken token)
         {
             //If no selection is made, return a problem and exit early
             if (variablesSelection is null)
@@ -87,6 +98,7 @@ namespace PxWeb.Code.Api2
             }
 
 
+            token.ThrowIfCancellationRequested();
             // Expand and verify the selections
             if (!_selectionHandler.ExpandAndVerfiySelections(variablesSelection, builder, out problem))
             {
@@ -107,6 +119,7 @@ namespace PxWeb.Code.Api2
             //Fix selection loses all values after BuildForPresentation
             var selectionCopy = SelectionUtil.Copy(selection);
 
+            token.ThrowIfCancellationRequested();
             builder.BuildForPresentation(selection);
 
             selection = selectionCopy;
@@ -133,6 +146,8 @@ namespace PxWeb.Code.Api2
                 }));
 
                 var pivot = new PCAxis.Paxiom.Operations.Pivot();
+
+                token.ThrowIfCancellationRequested();
                 model = pivot.Execute(model, descriptions.ToArray());
             }
 

--- a/PxWeb/Code/Api2/IDataWorkflow.cs
+++ b/PxWeb/Code/Api2/IDataWorkflow.cs
@@ -1,4 +1,6 @@
-﻿using PCAxis.Paxiom;
+﻿using System.Threading;
+
+using PCAxis.Paxiom;
 
 using PxWeb.Api2.Server.Models;
 
@@ -6,7 +8,7 @@ namespace PxWeb.Code.Api2
 {
     public interface IDataWorkflow
     {
-        PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem);
-        PXModel? Run(string tableId, string language, out Problem? problem);
+        PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem, CancellationToken token);
+        PXModel? Run(string tableId, string language, out Problem? problem, CancellationToken token);
     }
 }

--- a/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
+++ b/PxWeb/Config/Api2/PxApiConfigurationOptions.cs
@@ -28,6 +28,7 @@ namespace PxWeb.Config.Api2
         public string CacheClearTime { get; set; } = string.Empty;
         public string SearchEngine { get; set; } = string.Empty;
         public int PageSize { get; set; } = 20;
+        public int GetTableDataTimeoutSeconds { get; set; } = 40;
         public string BaseURL { get; set; } = string.Empty;
         public string RoutePrefix { get; set; } = string.Empty;
         public List<string> OutputFormats { get; set; } = [];

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -49,6 +50,7 @@ namespace PxWeb.Controllers.Api2
             _savedQueryResponseMapper = (SavedQueryResponseMapper)savedQueryResponseMapper;
         }
 
+        [RequestTimeout("GetTableDataTimeout")]
         public override IActionResult CreateSaveQuery([FromBody] SavedQuery? savedQuery)
         {
             Problem? problem;
@@ -123,6 +125,7 @@ namespace PxWeb.Controllers.Api2
             return Ok(_savedQueryResponseMapper.Map(savedQuery));
         }
 
+        [RequestTimeout("GetTableDataTimeout")]
         public override IActionResult RunSaveQuery([FromRoute(Name = "id"), Required] string id, [FromQuery(Name = "lang")] string? lang, [FromQuery(Name = "outputFormat")] OutputFormatType? outputFormat, [FromQuery(Name = "outputFormatParams")] List<OutputFormatParamType>? outputFormatParams)
         {
             Problem? problem;

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -66,9 +66,9 @@ namespace PxWeb.Controllers.Api2
             {
                 _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, variablesSelection, out problem, HttpContext.RequestAborted);
             }
-            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogInformation("Request timeout for table data.");
+                _logger.LogInformation(ex, "Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",
@@ -171,9 +171,9 @@ namespace PxWeb.Controllers.Api2
             {
                 model = _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, savedQuery.Selection, out problem, HttpContext.RequestAborted);
             }
-            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogInformation("Request timeout for table data.");
+                _logger.LogInformation(ex, "Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using PCAxis.Paxiom;
+
 using Px.Abstractions.Interfaces;
 
 using PxWeb.Api2.Server.Models;
@@ -60,8 +62,21 @@ namespace PxWeb.Controllers.Api2
             // Create a copy of the selection to be able to expand it
             var variablesSelection = SelectionUtil.Copy(savedQuery.Selection);
 
-            _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, variablesSelection, out problem);
-
+            try
+            {
+                _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, variablesSelection, out problem, HttpContext.RequestAborted);
+            }
+            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                _logger.LogWarning("Request timeout for table data.");
+                return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
+                {
+                    Type = "Timeout",
+                    Status = StatusCodes.Status504GatewayTimeout,
+                    Title = "Request timeout",
+                    Detail = "The request took too long to complete."
+                });
+            }
             if (problem is not null)
             {
                 return BadRequest(problem);
@@ -151,7 +166,22 @@ namespace PxWeb.Controllers.Api2
             }
 
             // 4. Run the SavedQuery
-            var model = _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, savedQuery.Selection, out problem);
+            PXModel? model;
+            try
+            {
+                model = _dataWorkflow.Run(savedQuery.TableId, savedQuery.Language, savedQuery.Selection, out problem, HttpContext.RequestAborted);
+            }
+            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                _logger.LogWarning("Request timeout for table data.");
+                return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
+                {
+                    Type = "Timeout",
+                    Status = StatusCodes.Status504GatewayTimeout,
+                    Title = "Request timeout",
+                    Detail = "The request took too long to complete."
+                });
+            }
 
             if (model is null)
             {

--- a/PxWeb/Controllers/Api2/SavedQueryApiController.cs
+++ b/PxWeb/Controllers/Api2/SavedQueryApiController.cs
@@ -68,7 +68,7 @@ namespace PxWeb.Controllers.Api2
             }
             catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogWarning("Request timeout for table data.");
+                _logger.LogInformation("Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",
@@ -173,7 +173,7 @@ namespace PxWeb.Controllers.Api2
             }
             catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogWarning("Request timeout for table data.");
+                _logger.LogInformation("Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -253,19 +253,18 @@ namespace PxWeb.Controllers.Api2
                     {
                         _logger.LogDataExctractionBySavedQuery(savedQuery.Id ?? "Unknown");
                         variablesSelection = savedQuery.Selection;
-                        // TODO pass the cancelation tocken into the the Run method so it can cansel the processing
-                        model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
+                        model = _dataWorkflow.Run(id, lang, variablesSelection, out problem, HttpContext.RequestAborted);
                     }
                     else
                     {
                         _logger.LogDataExctractionByAlgorithm();
-                        model = _dataWorkflow.Run(id, lang, out problem);
+                        model = _dataWorkflow.Run(id, lang, out problem, HttpContext.RequestAborted);
                     }
                 }
                 else
                 {
                     _logger.LogDataExctractionBySelection();
-                    model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
+                    model = _dataWorkflow.Run(id, lang, variablesSelection, out problem, HttpContext.RequestAborted);
                 }
 
                 if (model is null)
@@ -274,9 +273,10 @@ namespace PxWeb.Controllers.Api2
                     return BadRequest(problem);
                 }
 
-                var serializationInfo = _serializeManager.GetSerializer(outputFormatStr, model.Meta.CodePage, outputFormatParamsStr);
 
                 HttpContext.RequestAborted.ThrowIfCancellationRequested();
+                var serializationInfo = _serializeManager.GetSerializer(outputFormatStr, model.Meta.CodePage, outputFormatParamsStr);
+
 
                 Response.ContentType = serializationInfo.ContentType;
                 Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -288,7 +288,7 @@ namespace PxWeb.Controllers.Api2
             }
             catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogWarning("Request timeout for table data. Id: {TableId}", id);
+                _logger.LogWarning("Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -288,7 +288,7 @@ namespace PxWeb.Controllers.Api2
             }
             catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogWarning("Request timeout for table data.");
+                _logger.LogInformation("Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -286,9 +286,9 @@ namespace PxWeb.Controllers.Api2
 
                 return Ok();
             }
-            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogInformation("Request timeout for table data.");
+                _logger.LogInformation(ex, "Request timeout for table data.");
                 return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
                 {
                     Type = "Timeout",

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -195,6 +196,7 @@ namespace PxWeb.Controllers.Api2
 
         }
 
+        [RequestTimeout("GetTableDataTimeout")]
         public override IActionResult GetTableData(
             [FromRoute(Name = "id"), Required] string id,
             [FromQuery(Name = "lang")] string? lang,
@@ -209,6 +211,7 @@ namespace PxWeb.Controllers.Api2
             return GetData(id, lang, variablesSelection, outputFormat, outputFormatParams is null ? new List<OutputFormatParamType>() : outputFormatParams);
         }
 
+        [RequestTimeout("GetTableDataTimeout")]
         public override IActionResult GetTableDataByPost(
             [FromRoute(Name = "id"), Required] string id,
             [FromQuery(Name = "lang")] string? lang,
@@ -219,63 +222,81 @@ namespace PxWeb.Controllers.Api2
             return GetData(id, lang, variablesSelection, outputFormat, outputFormatParams is null ? new List<OutputFormatParamType>() : outputFormatParams);
         }
 
+
         private IActionResult GetData(string id, string? lang, VariablesSelection? variablesSelection, OutputFormatType? outputFormat, List<OutputFormatParamType> outputFormatParams)
         {
 
-            Problem? problem = null;
-
-            lang = _languageHelper.HandleLanguage(lang);
-
-            bool paramError;
-            string outputFormatStr;
-            List<string> outputFormatParamsStr;
-
-            (outputFormatStr, outputFormatParamsStr) = OutputParameterUtil.TranslateOutputParamters(outputFormat, _configOptions, outputFormatParams, out paramError);
-
-            if (paramError)
+            try
             {
-                _logger.LogUnsupportedOutputFormat(outputFormatStr);
-                return BadRequest(ProblemUtility.UnsupportedOutputFormat());
-            }
+                Problem? problem = null;
 
-            PXModel? model;
+                lang = _languageHelper.HandleLanguage(lang);
 
-            if (SelectionUtil.UseDefaultSelection(variablesSelection))
-            {
-                var savedQuery = _savedQueryBackendProxy.LoadDefaultSelection(id);
-                if (savedQuery is not null)
+                bool paramError;
+                string outputFormatStr;
+                List<string> outputFormatParamsStr;
+
+                (outputFormatStr, outputFormatParamsStr) = OutputParameterUtil.TranslateOutputParamters(outputFormat, _configOptions, outputFormatParams, out paramError);
+
+                if (paramError)
                 {
-                    _logger.LogDataExctractionBySavedQuery(savedQuery.Id ?? "Unknown");
-                    variablesSelection = savedQuery.Selection;
-                    model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
+                    _logger.LogUnsupportedOutputFormat(outputFormatStr);
+                    return BadRequest(ProblemUtility.UnsupportedOutputFormat());
+                }
+
+                PXModel? model;
+
+                if (SelectionUtil.UseDefaultSelection(variablesSelection))
+                {
+                    var savedQuery = _savedQueryBackendProxy.LoadDefaultSelection(id);
+                    if (savedQuery is not null)
+                    {
+                        _logger.LogDataExctractionBySavedQuery(savedQuery.Id ?? "Unknown");
+                        variablesSelection = savedQuery.Selection;
+                        // TODO pass the cancelation tocken into the the Run method so it can cansel the processing
+                        model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
+                    }
+                    else
+                    {
+                        _logger.LogDataExctractionByAlgorithm();
+                        model = _dataWorkflow.Run(id, lang, out problem);
+                    }
                 }
                 else
                 {
-                    _logger.LogDataExctractionByAlgorithm();
-                    model = _dataWorkflow.Run(id, lang, out problem);
+                    _logger.LogDataExctractionBySelection();
+                    model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
                 }
+
+                if (model is null)
+                {
+                    _logger.LogCouldNotRunWorkflowSucessfully();
+                    return BadRequest(problem);
+                }
+
+                var serializationInfo = _serializeManager.GetSerializer(outputFormatStr, model.Meta.CodePage, outputFormatParamsStr);
+
+                HttpContext.RequestAborted.ThrowIfCancellationRequested();
+
+                Response.ContentType = serializationInfo.ContentType;
+                Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
+                serializationInfo.Serializer.Serialize(model, Response.Body);
+
+                HttpContext.AddLoggingContext(id, outputFormatStr, model.Data.MatrixSize);
+
+                return Ok();
             }
-            else
+            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
-                _logger.LogDataExctractionBySelection();
-                model = _dataWorkflow.Run(id, lang, variablesSelection, out problem);
+                _logger.LogWarning("Request timeout for table data. Id: {TableId}", id);
+                return StatusCode(StatusCodes.Status504GatewayTimeout, new Problem
+                {
+                    Type = "Timeout",
+                    Status = StatusCodes.Status504GatewayTimeout,
+                    Title = "Request timeout",
+                    Detail = "The request took too long to complete."
+                });
             }
-
-            if (model is null)
-            {
-                _logger.LogCouldNotRunWorkflowSucessfully();
-                return BadRequest(problem);
-            }
-
-            var serializationInfo = _serializeManager.GetSerializer(outputFormatStr, model.Meta.CodePage, outputFormatParamsStr);
-
-            Response.ContentType = serializationInfo.ContentType;
-            Response.Headers.Append("Content-Disposition", $"inline; filename=\"{model.Meta.Matrix}{serializationInfo.Suffix}\"");
-            serializationInfo.Serializer.Serialize(model, Response.Body);
-
-            HttpContext.AddLoggingContext(id, outputFormatStr, model.Data.MatrixSize);
-
-            return Ok();
         }
 
 

--- a/PxWeb/Controllers/Api2/TablesApiController.cs
+++ b/PxWeb/Controllers/Api2/TablesApiController.cs
@@ -311,7 +311,7 @@ namespace PxWeb.Controllers.Api2
         /// <param name="heading"></param>
         /// <param name="stub"></param> 
         /// <returns></returns>
-        private VariablesSelection MapDataParameters(Dictionary<string, List<string>>? valuecodes, Dictionary<string, string>? codelist, List<string>? heading, List<string>? stub)
+        private static VariablesSelection MapDataParameters(Dictionary<string, List<string>>? valuecodes, Dictionary<string, string>? codelist, List<string>? heading, List<string>? stub)
         {
             VariablesSelection selections = new VariablesSelection();
             if (valuecodes != null)

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -39,6 +39,7 @@ namespace PxWeb
     {
         const string AdminPath = "/admin";
         const string GetTableDataTimeoutPolicy = "GetTableDataTimeout";
+        const int DefaultGetTableDataTimeoutSeconds = 40;
         static PxApiConfigurationOptions PxApiConfiguration { get; set; } = new PxApiConfigurationOptions();
         static bool CorsEnabled { get; set; }
 
@@ -84,9 +85,17 @@ namespace PxWeb
 
             builder.Services.AddRequestTimeouts(options =>
             {
+                var configuredTimeoutSeconds = builder.Configuration.GetValue<int?>("PxApiConfiguration:GetTableDataTimeoutSeconds");
+                var timeoutSeconds = configuredTimeoutSeconds.GetValueOrDefault(DefaultGetTableDataTimeoutSeconds);
+
+                if (timeoutSeconds <= 0)
+                {
+                    timeoutSeconds = DefaultGetTableDataTimeoutSeconds;
+                }
+
                 options.AddPolicy(GetTableDataTimeoutPolicy, new RequestTimeoutPolicy
                 {
-                    Timeout = TimeSpan.FromSeconds(20)
+                    Timeout = TimeSpan.FromSeconds(timeoutSeconds)
                 });
             });
 

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -6,6 +6,7 @@ using AspNetCoreRateLimit;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -37,6 +38,7 @@ namespace PxWeb
     class Program
     {
         const string AdminPath = "/admin";
+        const string GetTableDataTimeoutPolicy = "GetTableDataTimeout";
         static PxApiConfigurationOptions PxApiConfiguration { get; set; } = new PxApiConfigurationOptions();
         static bool CorsEnabled { get; set; }
 
@@ -79,6 +81,15 @@ namespace PxWeb
 
         static void RegisterServices(WebApplicationBuilder builder)
         {
+
+            builder.Services.AddRequestTimeouts(options =>
+            {
+                options.AddPolicy(GetTableDataTimeoutPolicy, new RequestTimeoutPolicy
+                {
+                    Timeout = TimeSpan.FromSeconds(20)
+                });
+            });
+
             // needed to load configuration from appsettings.json
             builder.Services.AddOptions();
 
@@ -195,6 +206,10 @@ namespace PxWeb
         {
             app.UseMiddleware<GlobalRoutePrefixMiddleware>(PxApiConfiguration.RoutePrefix);
             app.UsePathBase(new PathString(PxApiConfiguration.RoutePrefix));
+
+            app.UseRouting();
+            app.UseRequestTimeouts();
+
             app.UseSwagger(options => options.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
                 {
                     if (!(PxApiConfiguration.EnableAllEndpointsSwaggerUI || app.Environment.IsDevelopment()))
@@ -244,6 +259,8 @@ namespace PxWeb
             {
                 app.UseIpRateLimiting();
             }
+
+
 
             app.UseWhen(context => !(context.Request.Path.StartsWithSegments(PxApiConfiguration.RoutePrefix + AdminPath) || context.Request.Path.StartsWithSegments(AdminPath) || context.Request.Path.StartsWithSegments(PxApiConfiguration.RoutePrefix + "/healthz") || context.Request.Path.StartsWithSegments("/healthz")), appBuilder =>
             {

--- a/PxWeb/appsettings.md
+++ b/PxWeb/appsettings.md
@@ -3,3 +3,6 @@ The fields baseUrl and routePrefix should be
 so that f.x. the url to the config endpoint is baseUrl + routePrefix + "/config"
 Neither should end with a "/". If not empty routePrefix should start with a "/"    
 The baseUrl should hold the scheme (https normally) + the host + on IIS the virutal Path to the application if any.
+
+`PxApiConfiguration:GetTableDataTimeoutSeconds` controls request timeout for table data endpoints.
+Default value is `40` seconds.

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -1,7 +1,11 @@
 ﻿using System.Net;
 using System.Text;
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 
 using Newtonsoft.Json;
 
@@ -183,6 +187,34 @@ namespace PxWebApi_Mvc.Tests
 
             // Assert
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task Saved_query_that_takes_too_long_to_execute_should_not_be_created()
+        {
+            await using var application = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.PostConfigure<RequestTimeoutOptions>(options =>
+                        {
+                            options.Policies["GetTableDataTimeout"] = new RequestTimeoutPolicy
+                            {
+                                Timeout = TimeSpan.FromMilliseconds(1),
+                                TimeoutStatusCode = StatusCodes.Status504GatewayTimeout
+                            };
+                        });
+                    });
+                });
+
+            using var client = application.CreateClient();
+
+
+            var content = new StringContent(SavedQuery, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/savedqueries", content);
+
+            Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
         }
     }
 }

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -6,11 +6,15 @@ using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using Newtonsoft.Json;
 
 using PxWeb;
 using PxWeb.Api2.Server.Models;
+using PxWeb.Code.Api2;
+
+using PxWebApi_Mvc.Tests.Wrappers;
 
 namespace PxWebApi_Mvc.Tests
 {
@@ -199,6 +203,9 @@ namespace PxWebApi_Mvc.Tests
                 {
                     builder.ConfigureTestServices(services =>
                     {
+                        services.RemoveAll<IDataWorkflow>();
+                        services.AddSingleton<IDataWorkflow, CancellationAwareDataWorkflow>();
+
                         services.PostConfigure<RequestTimeoutOptions>(options =>
                         {
                             options.Policies["GetTableDataTimeout"] = new RequestTimeoutPolicy

--- a/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
+++ b/PxWebApi_Mvc.Tests/SavedQueryApiControllerTests.cs
@@ -17,6 +17,8 @@ namespace PxWebApi_Mvc.Tests
     [TestClass]
     public class SavedQueryApiControllerTests
     {
+        public TestContext TestContext { get; set; }
+
         private const string SavedQuery = @"{
                             ""language"": ""en"",
                             ""tableId"": ""TAB001"",
@@ -212,7 +214,7 @@ namespace PxWebApi_Mvc.Tests
 
 
             var content = new StringContent(SavedQuery, Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("/savedqueries", content);
+            var response = await client.PostAsync("/savedqueries", content, TestContext.CancellationToken);
 
             Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
         }

--- a/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
+++ b/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
@@ -5,8 +5,12 @@ using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using PxWeb;
+using PxWeb.Code.Api2;
+
+using PxWebApi_Mvc.Tests.Wrappers;
 
 namespace PxWebApi_Mvc.Tests
 {
@@ -170,6 +174,7 @@ namespace PxWebApi_Mvc.Tests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         public async Task Cancelling_request_should_return_timeout()
         {
             await using var application = new WebApplicationFactory<Program>()
@@ -177,11 +182,14 @@ namespace PxWebApi_Mvc.Tests
                 {
                     builder.ConfigureTestServices(services =>
                     {
+                        services.RemoveAll<IDataWorkflow>();
+                        services.AddSingleton<IDataWorkflow, CancellationAwareDataWorkflow>();
+
                         services.PostConfigure<RequestTimeoutOptions>(options =>
                         {
                             options.Policies["GetTableDataTimeout"] = new RequestTimeoutPolicy
                             {
-                                Timeout = TimeSpan.FromMilliseconds(1),
+                                Timeout = TimeSpan.FromMilliseconds(50),
                                 TimeoutStatusCode = StatusCodes.Status504GatewayTimeout
                             };
                         });
@@ -194,7 +202,6 @@ namespace PxWebApi_Mvc.Tests
 
             Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
         }
-
 
 
     }

--- a/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
+++ b/PxWebApi_Mvc.Tests/TableApiControllerTest.cs
@@ -1,6 +1,10 @@
 using System.Net;
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 
 using PxWeb;
 
@@ -164,6 +168,34 @@ namespace PxWebApi_Mvc.Tests
 
 
         }
+
+        [TestMethod]
+        public async Task Cancelling_request_should_return_timeout()
+        {
+            await using var application = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.PostConfigure<RequestTimeoutOptions>(options =>
+                        {
+                            options.Policies["GetTableDataTimeout"] = new RequestTimeoutPolicy
+                            {
+                                Timeout = TimeSpan.FromMilliseconds(1),
+                                TimeoutStatusCode = StatusCodes.Status504GatewayTimeout
+                            };
+                        });
+                    });
+                });
+
+            using var client = application.CreateClient();
+
+            var response = await client.GetAsync("/tables/tab003/data?lang=en", TestContext.CancellationToken);
+
+            Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
+        }
+
+
 
     }
 }

--- a/PxWebApi_Mvc.Tests/Wrappers/CancellationAwareDataWorkflow.cs
+++ b/PxWebApi_Mvc.Tests/Wrappers/CancellationAwareDataWorkflow.cs
@@ -1,0 +1,34 @@
+﻿using PCAxis.Paxiom;
+
+using PxWeb.Api2.Server.Models;
+using PxWeb.Code.Api2;
+
+namespace PxWebApi_Mvc.Tests.Wrappers
+{
+    internal sealed class CancellationAwareDataWorkflow : IDataWorkflow
+    {
+        public PXModel? Run(string tableId, string language, VariablesSelection? variablesSelection, out Problem? problem, CancellationToken token)
+        {
+            problem = null;
+            WaitForCancellation(token);
+            return null;
+        }
+
+        public PXModel? Run(string tableId, string language, out Problem? problem, CancellationToken token)
+        {
+            problem = null;
+            WaitForCancellation(token);
+            return null;
+        }
+
+        private static void WaitForCancellation(CancellationToken token)
+        {
+            if (!token.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)))
+            {
+                throw new OperationCanceledException(token);
+            }
+
+            token.ThrowIfCancellationRequested();
+        }
+    }
+}


### PR DESCRIPTION
Introduced a `RequestTimeout` attribute to `GetTableData` and `GetTableDataByPost` methods to enforce a timeout
policy. Integrated `RequestTimeouts` middleware in the application pipeline and ensured it is applied selectively to relevant requests.