### PR TITLE
fix(source): Adds check for null on `SOURCE`

### DIFF
--- a/Px.Search.Lucene/LuceneIndex.cs
+++ b/Px.Search.Lucene/LuceneIndex.cs
@@ -218,7 +218,7 @@ namespace Px.Search.Lucene
             doc.Add(new TextField(SearchConstants.SEARCH_FIELD_VALUESETCODES, meta.GetAllValuesetCodes(), Field.Store.NO));
             doc.Add(new TextField(SearchConstants.SEARCH_FIELD_DISCONTINUED, tbl.Discontinued == null ? "Unknown" : tbl.Discontinued.ToString(), Field.Store.YES));
             doc.Add(new TextField(SearchConstants.SEARCH_FIELD_TAGS, GetAllTags(tbl.Tags), Field.Store.YES));
-            doc.Add(new TextField(SearchConstants.SEARCH_FIELD_SOURCE, tbl.Source, Field.Store.YES));
+            doc.Add(new TextField(SearchConstants.SEARCH_FIELD_SOURCE, tbl.Source ?? "", Field.Store.YES));
             doc.Add(new TextField(SearchConstants.SEARCH_FIELD_TIME_UNIT, tbl.TimeUnit, Field.Store.YES));
             doc.Add(new TextField(SearchConstants.SEARCH_SUBJECT_CODE, tbl.SubjectCode, Field.Store.YES));
             doc.Add(new StoredField(SearchConstants.SEARCH_FIELD_PATHS, GetBytes(tbl.Paths)));


### PR DESCRIPTION
Adds a check when creating a search index that `SOURCE` is not `null` since it is not a mandatory keyword in PX files.