### PR TITLE
fix(search): Change to tokenizer to  `WhitespaceTokenizer`

### DIFF
--- a/Px.Search.Lucene/CaseInsensitiveKeywordAnalyzer.cs
+++ b/Px.Search.Lucene/CaseInsensitiveKeywordAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Px.Search.Lucene
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
         {
             // Keeps the text as a single token (no word splitting)
-            Tokenizer source = new KeywordTokenizer(reader);
+            Tokenizer source = new WhitespaceTokenizer(LuceneVersion.LUCENE_48, reader);
 
             // Converts that single token to lowercase
             TokenStream filter = new LowerCaseFilter(LuceneVersion.LUCENE_48, source);


### PR DESCRIPTION
Change the tokenizer to `WhitespaceTokenizer` so that it does not treat the whole string as a single token