### PR TITLE
chore: Bump PCAxis.Sql and PCAxis.Core nuget packages versions

### DIFF
--- a/Px.Abstractions/Px.Abstractions.csproj
+++ b/Px.Abstractions/Px.Abstractions.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PCAxis.Core" Version="1.3.0" />
+    <PackageReference Include="PCAxis.Core" Version="1.4.3" />
     <PackageReference Include="PCAxis.Menu" Version="1.0.5" />
   </ItemGroup>
 

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.10" />
     <PackageReference Include="PCAxis.Serializers" Version="1.12.1" />
-    <PackageReference Include="PCAxis.Sql" Version="1.6.1" />
+    <PackageReference Include="PCAxis.Sql" Version="1.7.0" />
     <PackageReference Include="PxWeb.Api2.Server" Version="2.3.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.6" />

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.10" />
-    <PackageReference Include="PCAxis.Serializers" Version="1.12.1" />
+    <PackageReference Include="PCAxis.Serializers" Version="1.12.2" />
     <PackageReference Include="PCAxis.Sql" Version="1.7.2" />
     <PackageReference Include="PxWeb.Api2.Server" Version="2.3.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />

--- a/PxWeb/PxWeb.csproj
+++ b/PxWeb/PxWeb.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu" Version="1.0.10" />
     <PackageReference Include="PCAxis.Serializers" Version="1.12.1" />
-    <PackageReference Include="PCAxis.Sql" Version="1.7.0" />
+    <PackageReference Include="PCAxis.Sql" Version="1.7.2" />
     <PackageReference Include="PxWeb.Api2.Server" Version="2.3.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.6" />


### PR DESCRIPTION
Manual update of nuget package versions due to dependabot issue.

Upgraded PCAxis.Core from 1.3.0 to 1.4.3 in Px.Abstractions.csproj and PCAxis.Sql from 1.7.0 to 1.7.2 in PxWeb.csproj to incorporate latest encoding fixes. 

Upgraded PCAxis.Serializers from 1.12.1 to 1.12.2 in PxWeb.csproj.

Both top level and transitive dependencies of PCAxis.Core are updated.